### PR TITLE
fix: 修复子流程成功回调锁竞争丢失 --bug=1010131351157180998

### DIFF
--- a/.github/scripts/setup_pyenv_python.sh
+++ b/.github/scripts/setup_pyenv_python.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PYTHON_VERSION="${1:?python version is required}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  clang \
+  curl \
+  libbz2-dev \
+  libffi-dev \
+  liblzma-dev \
+  libncurses5-dev \
+  libncursesw5-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  llvm \
+  make \
+  tk-dev \
+  xz-utils \
+  zlib1g-dev
+
+curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+eval "$(pyenv init --path)"
+
+CC=clang pyenv install -s "${PYTHON_VERSION}" -v
+pyenv global "${PYTHON_VERSION}"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "${PYENV_ROOT}/bin" >> "${GITHUB_PATH}"
+  echo "${PYENV_ROOT}/shims" >> "${GITHUB_PATH}"
+fi
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "PYENV_ROOT=${PYENV_ROOT}" >> "${GITHUB_ENV}"
+  echo "PYENV_VERSION=${PYTHON_VERSION}" >> "${GITHUB_ENV}"
+fi
+
+python -VV
+python -m site

--- a/.github/workflows/engine_flake8_and_black.yml
+++ b/.github/workflows/engine_flake8_and_black.yml
@@ -10,18 +10,16 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 black
+        pip install flake8==4.0.1 black==20.8b1
     - name: Lint with flake8
       run: |
         flake8 bamboo_engine/

--- a/.github/workflows/engine_unittest.yml
+++ b/.github/workflows/engine_unittest.yml
@@ -10,13 +10,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} with pyenv
+        run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           set -xe

--- a/.github/workflows/pipeline_end_to_end_test.yml
+++ b/.github/workflows/pipeline_end_to_end_test.yml
@@ -13,16 +13,14 @@ jobs:
       DB_PASSWORD: root
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
         django-version: [2.2, 3.0]
 
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
     - name: Set up MySQL
       run: |
@@ -66,4 +64,3 @@ jobs:
         PIPELINE_TEST_DB_NAME: pipeline_test
         PIPELINE_TEST_DB_USER: root
         PIPELINE_TEST_DB_PWD: root
-

--- a/.github/workflows/runtime_pipeline_end_to_end_test.yml
+++ b/.github/workflows/runtime_pipeline_end_to_end_test.yml
@@ -13,16 +13,14 @@ jobs:
       DB_PASSWORD: root
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
         django-version: [2.2, 3.0]
 
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
     - name: Set up MySQL
       run: |

--- a/.github/workflows/runtime_pipeline_flake8_and_black.yml
+++ b/.github/workflows/runtime_pipeline_flake8_and_black.yml
@@ -10,18 +10,16 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 black
+        pip install flake8==4.0.1 black==20.8b1
     - name: Lint with flake8
       run: |
         cd runtime/bamboo-pipeline

--- a/.github/workflows/runtime_pipeline_unittest.yml
+++ b/.github/workflows/runtime_pipeline_unittest.yml
@@ -13,16 +13,14 @@ jobs:
       DB_PASSWORD: root
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
         django-version: [2.2, 3.0]
 
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
     - name: Set up MySQL
       run: |

--- a/bamboo_engine/engine.py
+++ b/bamboo_engine/engine.py
@@ -1048,9 +1048,7 @@ class Engine:
                 try_after = random.randint(1, 5)
                 retry_headers = dict(headers or {})
                 if schedule.type is ScheduleType.CALLBACK:
-                    retry_headers[self.CALLBACK_LOCK_RETRY_HEADER] = (
-                        self._schedule_lock_retry_count(headers) + 1
-                    )
+                    retry_headers[self.CALLBACK_LOCK_RETRY_HEADER] = self._schedule_lock_retry_count(headers) + 1
                 logger.info(
                     "root pipeline[%s] schedule(%s) lock %s with data %s fetch fail, try after %s, "
                     "retry_count=%s, callback_data=%s",

--- a/bamboo_engine/engine.py
+++ b/bamboo_engine/engine.py
@@ -78,10 +78,30 @@ class Engine:
     """
 
     PURE_SKIP_ENABLE_NODE_TYPE = {NodeType.ServiceActivity, NodeType.EmptyStartEvent}
+    CALLBACK_LOCK_RETRY_HEADER = "callback_lock_retry_times"
+    CALLBACK_LOCK_RETRY_LIMIT = 3
 
     def __init__(self, runtime: EngineRuntimeInterface):
         self.runtime = runtime
         self._hostname = get_hostname()
+
+    def _schedule_lock_retry_count(self, headers: Optional[dict]) -> int:
+        if not headers:
+            return 0
+
+        try:
+            return int(headers.get(self.CALLBACK_LOCK_RETRY_HEADER, 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def _callback_lock_retry_context(self, node_id: str, callback_data_id: Optional[int]):
+        if not callback_data_id:
+            return None, False
+
+        callback_data = self.runtime.get_callback_data(callback_data_id)
+        node = self.runtime.get_node(node_id)
+        service = self.runtime.get_service(code=node.code, version=node.version)
+        return callback_data, service.callback_lock_retryable(callback_data=callback_data.data)
 
     # api
     def run_pipeline(
@@ -993,25 +1013,54 @@ class Engine:
             interrupter.check_and_set(ScheduleKeyPoint.APPLY_LOCK_DONE, lock_get=lock_get)
 
             if not lock_get:
-                # only retry at multiple calback type
-                if schedule.type is not ScheduleType.MULTIPLE_CALLBACK:
+                callback_data = None
+                # only retry at multiple callback type
+                should_retry = schedule.type is ScheduleType.MULTIPLE_CALLBACK
+                if not should_retry:
+                    callback_data, should_retry = self._callback_lock_retry_context(node_id, callback_data_id)
+                    retry_count = self._schedule_lock_retry_count(headers)
+                    if should_retry and retry_count >= self.CALLBACK_LOCK_RETRY_LIMIT:
+                        logger.error(
+                            "root pipeline[%s] schedule(%s) %s with version %s callback data(%s) retry exhausted "
+                            "after %s attempts, callback_data=%s",
+                            root_pipeline_id,
+                            schedule_id,
+                            node_id,
+                            schedule.version,
+                            callback_data_id,
+                            retry_count,
+                            callback_data.data if callback_data else None,
+                        )
+                        return
+
+                if not should_retry:
                     logger.info(
-                        "root pipeline[%s] schedule(%s) %s with version %s is not multiple callback type, will not retry to get lock",  # noqa
+                        "root pipeline[%s] schedule(%s) %s with version %s callback data(%s) "
+                        "will not retry to get lock",
                         root_pipeline_id,
                         schedule_id,
                         node_id,
                         schedule.version,
+                        callback_data_id,
                     )
                     return
 
                 try_after = random.randint(1, 5)
+                retry_headers = dict(headers or {})
+                if schedule.type is ScheduleType.CALLBACK:
+                    retry_headers[self.CALLBACK_LOCK_RETRY_HEADER] = (
+                        self._schedule_lock_retry_count(headers) + 1
+                    )
                 logger.info(
-                    "root pipeline[%s] schedule(%s) lock %s with data %s fetch fail, try after %s",
+                    "root pipeline[%s] schedule(%s) lock %s with data %s fetch fail, try after %s, "
+                    "retry_count=%s, callback_data=%s",
                     root_pipeline_id,
                     node_id,
                     schedule_id,
                     callback_data_id,
                     try_after,
+                    retry_headers.get(self.CALLBACK_LOCK_RETRY_HEADER, 0),
+                    callback_data.data if callback_data else None,
                 )
                 self.runtime.set_next_schedule(
                     process_id=process_id,
@@ -1019,7 +1068,7 @@ class Engine:
                     schedule_id=schedule_id,
                     callback_data_id=callback_data_id,
                     schedule_after=try_after,
-                    headers=headers,
+                    headers=retry_headers,
                 )
                 return
 

--- a/runtime/bamboo-pipeline/pipeline/core/flow/activity/service_activity.py
+++ b/runtime/bamboo-pipeline/pipeline/core/flow/activity/service_activity.py
@@ -101,6 +101,9 @@ class Service(object, metaclass=ABCMeta):
     def multi_callback_enabled(self):
         return getattr(self, self.multi_callback_determine_attr, False)
 
+    def callback_lock_retryable(self, callback_data=None):
+        return False
+
     def clean_status(self):
         setattr(self, self.schedule_result_attr, False)
 

--- a/tests/engine/test_engine_schedule.py
+++ b/tests/engine/test_engine_schedule.py
@@ -214,7 +214,9 @@ def test_schedule__lock_get_failed_and_retry_enabled_callback(node_id, schedule_
     runtime.get_service = MagicMock(return_value=service)
 
     engine = Engine(runtime=runtime)
-    engine.schedule(pi.process_id, node_id, schedule_id, interrupter, callback_data_id=callback_data.id, headers=interrupter.headers)
+    engine.schedule(
+        pi.process_id, node_id, schedule_id, interrupter, callback_data_id=callback_data.id, headers=interrupter.headers
+    )
 
     runtime.get_callback_data.assert_called_once_with(callback_data.id)
     runtime.get_node.assert_called_once_with(node_id)

--- a/tests/engine/test_engine_schedule.py
+++ b/tests/engine/test_engine_schedule.py
@@ -179,6 +179,117 @@ def test_schedule__lock_get_failed_but_not_retry(node_id, schedule_id, state, pi
     assert interrupter.check_point.lock_get is False
 
 
+def test_schedule__lock_get_failed_and_retry_enabled_callback(node_id, schedule_id, state, pi, schedule, interrupter):
+    schedule.type = ScheduleType.CALLBACK
+    callback_data = CallbackData(
+        id=1,
+        node_id=node_id,
+        version=state.version,
+        data={"task_success": True},
+    )
+    service = MagicMock()
+    service.callback_lock_retryable = MagicMock(return_value=True)
+    node = ServiceActivity(
+        id=node_id,
+        type=NodeType.ServiceActivity,
+        target_flows=["f1"],
+        target_nodes=["t1"],
+        targets={"f1": "t1"},
+        root_pipeline_id="root",
+        parent_pipeline_id="root",
+        code="subprocess_plugin",
+        version="1.0.0",
+        error_ignorable=False,
+    )
+
+    interrupter.headers = {"route_info": {"queue": "default", "priority": 500}}
+
+    runtime = MagicMock()
+    runtime.get_process_info = MagicMock(return_value=pi)
+    runtime.apply_schedule_lock = MagicMock(return_value=False)
+    runtime.get_state = MagicMock(return_value=state)
+    runtime.get_schedule = MagicMock(return_value=schedule)
+    runtime.get_callback_data = MagicMock(return_value=callback_data)
+    runtime.get_node = MagicMock(return_value=node)
+    runtime.get_service = MagicMock(return_value=service)
+
+    engine = Engine(runtime=runtime)
+    engine.schedule(pi.process_id, node_id, schedule_id, interrupter, callback_data_id=callback_data.id, headers=interrupter.headers)
+
+    runtime.get_callback_data.assert_called_once_with(callback_data.id)
+    runtime.get_node.assert_called_once_with(node_id)
+    runtime.get_service.assert_called_once_with(code=node.code, version=node.version)
+    set_next_schedule_kwargs = runtime.set_next_schedule.call_args[1]
+    assert set_next_schedule_kwargs["process_id"] == pi.process_id
+    assert set_next_schedule_kwargs["node_id"] == node_id
+    assert set_next_schedule_kwargs["schedule_id"] == schedule_id
+    assert set_next_schedule_kwargs["callback_data_id"] == callback_data.id
+    assert set_next_schedule_kwargs["schedule_after"] <= 5
+    assert set_next_schedule_kwargs["headers"]["callback_lock_retry_times"] == 1
+    runtime.beat.assert_not_called()
+
+    assert interrupter.check_point.name == ScheduleKeyPoint.APPLY_LOCK_DONE
+    assert interrupter.check_point.version_mismatch is False
+    assert interrupter.check_point.node_not_running is False
+    assert interrupter.check_point.lock_get is False
+
+
+def test_schedule__lock_get_failed_and_retry_enabled_callback_reaches_retry_limit(
+    node_id, schedule_id, state, pi, schedule, interrupter
+):
+    schedule.type = ScheduleType.CALLBACK
+    callback_data = CallbackData(
+        id=1,
+        node_id=node_id,
+        version=state.version,
+        data={"task_success": True},
+    )
+    service = MagicMock()
+    service.callback_lock_retryable = MagicMock(return_value=True)
+    node = ServiceActivity(
+        id=node_id,
+        type=NodeType.ServiceActivity,
+        target_flows=["f1"],
+        target_nodes=["t1"],
+        targets={"f1": "t1"},
+        root_pipeline_id="root",
+        parent_pipeline_id="root",
+        code="subprocess_plugin",
+        version="1.0.0",
+        error_ignorable=False,
+    )
+
+    runtime = MagicMock()
+    runtime.get_process_info = MagicMock(return_value=pi)
+    runtime.apply_schedule_lock = MagicMock(return_value=False)
+    runtime.get_state = MagicMock(return_value=state)
+    runtime.get_schedule = MagicMock(return_value=schedule)
+    runtime.get_callback_data = MagicMock(return_value=callback_data)
+    runtime.get_node = MagicMock(return_value=node)
+    runtime.get_service = MagicMock(return_value=service)
+
+    engine = Engine(runtime=runtime)
+    engine.schedule(
+        pi.process_id,
+        node_id,
+        schedule_id,
+        interrupter,
+        callback_data_id=callback_data.id,
+        headers={"callback_lock_retry_times": 3},
+    )
+
+    runtime.get_callback_data.assert_called_once_with(callback_data.id)
+    runtime.get_node.assert_called_once_with(node_id)
+    runtime.get_service.assert_called_once_with(code=node.code, version=node.version)
+    runtime.set_next_schedule.assert_not_called()
+    runtime.beat.assert_not_called()
+
+    assert interrupter.check_point.name == ScheduleKeyPoint.APPLY_LOCK_DONE
+    assert interrupter.check_point.version_mismatch is False
+    assert interrupter.check_point.node_not_running is False
+    assert interrupter.check_point.lock_get is False
+
+
 def test_schedule__schedule_is_finished(node_id, pi, schedule, interrupter):
     schedule.finished = True
 


### PR DESCRIPTION
## Summary
- 为 `CALLBACK` 节点补充默认关闭、按 service 精确开启的有界锁冲突重试能力
- 保持普通 `CALLBACK` 和 `MULTIPLE_CALLBACK` 既有语义不变，仅为一期独立子流程成功 callback 提供运行时底座
- 增加引擎侧回归测试，覆盖“可重试 callback”和“不可重试 callback”两条分支

## Test Plan
- [x] `/Users/dengyh/.pyenv/versions/3.6.15/bin/python -m pytest tests/engine/test_engine_schedule.py -k 'lock_get_failed_and_retry_enabled_callback or lock_get_failed_but_not_retry' -q`