### PR TITLE
fix: 修复 callback 锁重试 ServiceWrapper 缺失

### DIFF
--- a/bamboo_engine/engine.py
+++ b/bamboo_engine/engine.py
@@ -80,6 +80,7 @@ class Engine:
     PURE_SKIP_ENABLE_NODE_TYPE = {NodeType.ServiceActivity, NodeType.EmptyStartEvent}
     CALLBACK_LOCK_RETRY_HEADER = "callback_lock_retry_times"
     CALLBACK_LOCK_RETRY_LIMIT = 3
+    CALLBACK_LOCK_RETRY_DELAY_RANGES = ((1, 3), (3, 6), (6, 10))
 
     def __init__(self, runtime: EngineRuntimeInterface):
         self.runtime = runtime
@@ -102,6 +103,12 @@ class Engine:
         node = self.runtime.get_node(node_id)
         service = self.runtime.get_service(code=node.code, version=node.version)
         return callback_data, service.callback_lock_retryable(callback_data=callback_data.data)
+
+    def _callback_lock_retry_delay(self, retry_count: int) -> int:
+        delay_range = self.CALLBACK_LOCK_RETRY_DELAY_RANGES[
+            min(retry_count, len(self.CALLBACK_LOCK_RETRY_DELAY_RANGES) - 1)
+        ]
+        return random.randint(*delay_range)
 
     # api
     def run_pipeline(
@@ -1045,10 +1052,13 @@ class Engine:
                     )
                     return
 
-                try_after = random.randint(1, 5)
                 retry_headers = dict(headers or {})
                 if schedule.type is ScheduleType.CALLBACK:
-                    retry_headers[self.CALLBACK_LOCK_RETRY_HEADER] = self._schedule_lock_retry_count(headers) + 1
+                    current_retry_count = self._schedule_lock_retry_count(headers)
+                    try_after = self._callback_lock_retry_delay(current_retry_count)
+                    retry_headers[self.CALLBACK_LOCK_RETRY_HEADER] = current_retry_count + 1
+                else:
+                    try_after = random.randint(1, 5)
                 logger.info(
                     "root pipeline[%s] schedule(%s) lock %s with data %s fetch fail, try after %s, "
                     "retry_count=%s, callback_data=%s",

--- a/bamboo_engine/eri/interfaces.py
+++ b/bamboo_engine/eri/interfaces.py
@@ -114,6 +114,16 @@ class Service(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def callback_lock_retryable(self, callback_data=None) -> bool:
+        """
+        回调调度锁冲突时是否允许重试
+
+        :param callback_data: 回调数据
+        :return: 是否允许重试
+        :rtype: bool
+        """
+
+    @abstractmethod
     def schedule_after(
         self,
         schedule: Optional[Schedule],

--- a/runtime/bamboo-pipeline/pipeline/eri/imp/service.py
+++ b/runtime/bamboo-pipeline/pipeline/eri/imp/service.py
@@ -140,6 +140,16 @@ class ServiceWrapper(ServiceInterface):
         """
         return self.service.is_schedule_finished()
 
+    def callback_lock_retryable(self, callback_data=None) -> bool:
+        """
+        回调调度锁冲突时是否允许重试
+
+        :param callback_data: 回调数据
+        :return: 是否允许重试
+        :rtype: bool
+        """
+        return self.service.callback_lock_retryable(callback_data=callback_data)
+
     def schedule_after(
         self, schedule: Optional[Schedule], data: ExecutionData, root_pipeline_data: ExecutionData
     ) -> int:

--- a/runtime/bamboo-pipeline/pipeline/tests/eri/imp/test_service.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/eri/imp/test_service.py
@@ -132,6 +132,24 @@ class ServiceWrapperTestCase(TestCase):
         self.assertEqual(ServiceWrapper(S3()).schedule_type(), ScheduleType.CALLBACK)
         self.assertEqual(ServiceWrapper(S4()).schedule_type(), ScheduleType.MULTIPLE_CALLBACK)
 
+    def test_callback_lock_retryable(self):
+        class S(Service):
+            def __init__(self):
+                self.callback_data = None
+
+            def execute(self, data, parent_data):
+                pass
+
+            def callback_lock_retryable(self, callback_data=None):
+                self.callback_data = callback_data
+                return True
+
+        service = S()
+        callback_data = {"task_success": True}
+
+        self.assertTrue(ServiceWrapper(service).callback_lock_retryable(callback_data=callback_data))
+        self.assertEqual(service.callback_data, callback_data)
+
     def test_is_schedule_done(self):
         class S(Service):
             __need_schedule__ = True

--- a/tests/engine/test_engine_schedule.py
+++ b/tests/engine/test_engine_schedule.py
@@ -127,7 +127,8 @@ def recover_point():
     return ScheduleInterruptPoint(name="name")
 
 
-def test_schedule__lock_get_failed(node_id, schedule_id, state, pi, schedule, interrupter):
+@mock.patch("bamboo_engine.engine.random.randint", return_value=5)
+def test_schedule__lock_get_failed(random_randint, node_id, schedule_id, state, pi, schedule, interrupter):
 
     runtime = MagicMock()
     runtime.get_process_info = MagicMock(return_value=pi)
@@ -146,7 +147,8 @@ def test_schedule__lock_get_failed(node_id, schedule_id, state, pi, schedule, in
     assert runtime.set_next_schedule.call_args.kwargs["node_id"] == node_id
     assert runtime.set_next_schedule.call_args.kwargs["schedule_id"] == schedule_id
     assert runtime.set_next_schedule.call_args.kwargs["callback_data_id"] is None
-    assert runtime.set_next_schedule.call_args.kwargs["schedule_after"] <= 5
+    assert runtime.set_next_schedule.call_args.kwargs["schedule_after"] == 5
+    random_randint.assert_called_once_with(1, 5)
     runtime.beat.assert_not_called()
 
     assert interrupter.check_point.name == ScheduleKeyPoint.APPLY_LOCK_DONE
@@ -179,7 +181,10 @@ def test_schedule__lock_get_failed_but_not_retry(node_id, schedule_id, state, pi
     assert interrupter.check_point.lock_get is False
 
 
-def test_schedule__lock_get_failed_and_retry_enabled_callback(node_id, schedule_id, state, pi, schedule, interrupter):
+@mock.patch("bamboo_engine.engine.random.randint", return_value=3)
+def test_schedule__lock_get_failed_and_retry_enabled_callback(
+    random_randint, node_id, schedule_id, state, pi, schedule, interrupter
+):
     schedule.type = ScheduleType.CALLBACK
     callback_data = CallbackData(
         id=1,
@@ -226,14 +231,73 @@ def test_schedule__lock_get_failed_and_retry_enabled_callback(node_id, schedule_
     assert set_next_schedule_kwargs["node_id"] == node_id
     assert set_next_schedule_kwargs["schedule_id"] == schedule_id
     assert set_next_schedule_kwargs["callback_data_id"] == callback_data.id
-    assert set_next_schedule_kwargs["schedule_after"] <= 5
+    assert set_next_schedule_kwargs["schedule_after"] == 3
     assert set_next_schedule_kwargs["headers"]["callback_lock_retry_times"] == 1
+    random_randint.assert_called_once_with(1, 3)
     runtime.beat.assert_not_called()
 
     assert interrupter.check_point.name == ScheduleKeyPoint.APPLY_LOCK_DONE
     assert interrupter.check_point.version_mismatch is False
     assert interrupter.check_point.node_not_running is False
     assert interrupter.check_point.lock_get is False
+
+
+@pytest.mark.parametrize(
+    "headers, expected_range, expected_retry_count",
+    [
+        ({}, (1, 3), 1),
+        ({"callback_lock_retry_times": 1}, (3, 6), 2),
+        ({"callback_lock_retry_times": 2}, (6, 10), 3),
+    ],
+)
+def test_schedule__lock_get_failed_and_retry_enabled_callback_uses_incremental_jitter(
+    headers, expected_range, expected_retry_count, node_id, schedule_id, state, pi, schedule, interrupter
+):
+    schedule.type = ScheduleType.CALLBACK
+    callback_data = CallbackData(
+        id=1,
+        node_id=node_id,
+        version=state.version,
+        data={"task_success": True},
+    )
+    service = MagicMock()
+    service.callback_lock_retryable = MagicMock(return_value=True)
+    node = ServiceActivity(
+        id=node_id,
+        type=NodeType.ServiceActivity,
+        target_flows=["f1"],
+        target_nodes=["t1"],
+        targets={"f1": "t1"},
+        root_pipeline_id="root",
+        parent_pipeline_id="root",
+        code="subprocess_plugin",
+        version="1.0.0",
+        error_ignorable=False,
+    )
+
+    runtime = MagicMock()
+    runtime.get_process_info = MagicMock(return_value=pi)
+    runtime.apply_schedule_lock = MagicMock(return_value=False)
+    runtime.get_state = MagicMock(return_value=state)
+    runtime.get_schedule = MagicMock(return_value=schedule)
+    runtime.get_callback_data = MagicMock(return_value=callback_data)
+    runtime.get_node = MagicMock(return_value=node)
+    runtime.get_service = MagicMock(return_value=service)
+
+    with mock.patch("bamboo_engine.engine.random.randint", return_value=expected_range[1]) as random_randint:
+        Engine(runtime=runtime).schedule(
+            pi.process_id,
+            node_id,
+            schedule_id,
+            interrupter,
+            callback_data_id=callback_data.id,
+            headers=headers,
+        )
+
+    set_next_schedule_kwargs = runtime.set_next_schedule.call_args[1]
+    assert set_next_schedule_kwargs["schedule_after"] == expected_range[1]
+    assert set_next_schedule_kwargs["headers"]["callback_lock_retry_times"] == expected_retry_count
+    random_randint.assert_called_once_with(*expected_range)
 
 
 def test_schedule__lock_get_failed_and_retry_enabled_callback_reaches_retry_limit(


### PR DESCRIPTION
## 变更说明

- 补充 ERI Service 接口中的 callback_lock_retryable 声明。
- 在 bamboo-pipeline ServiceWrapper 中转发 callback_lock_retryable 到插件 Service。
- 普通 CALLBACK 的可重试锁冲突改为三档递增 jitter：1-3s、3-6s、6-10s。
- MULTIPLE_CALLBACK 保持原有锁冲突重试策略：随机 1-5s。
- 增加 ServiceWrapper 转发行为和 callback 递增重试行为单测。

## 验证

- PYTHONPATH=<worktree>:<worktree>/runtime/bamboo-pipeline python3.6 -m pytest tests/engine/test_engine_schedule.py -q
- DJANGO_SETTINGS_MODULE=pipeline_sdk_use.settings PYTHONPATH=<worktree>:<worktree>/runtime/bamboo-pipeline:<worktree>/runtime/bamboo-pipeline/test python3.6 -m pytest ../pipeline/tests/eri/imp/test_service.py -q
- python -m black --check bamboo_engine/engine.py tests/engine/test_engine_schedule.py

bug: 1010131351157180998