### PR TITLE
fix(mako): root-name whitelist + dangerous-attr block (releases 2.11.2 / 3.29.8)

### DIFF
--- a/bamboo_engine/config.py
+++ b/bamboo_engine/config.py
@@ -65,6 +65,17 @@ class Settings:
 
     MAKO_SANDBOX_IMPORT_MODULES = {}
 
+    # 模板根标识符白名单模式：
+    #   "off"     - 关闭白名单（兼容历史行为）
+    #   "warn"    - 仅记录违规日志，不阻断渲染（灰度阶段使用）
+    #   "enforce" - 违规即按当前 deny-list 风格拦截（行为同 ForbiddenMakoTemplateException）
+    # 默认 "off"，由具体接入方按节奏开启。
+    MAKO_TEMPLATE_NAME_WHITELIST_MODE = "off"
+
+    # 在白名单基础上额外允许的根标识符（除 context/导入模块/SAFE_BUILTIN_NAMES 之外）。
+    # 接入方通常用于声明 ``_system``、``_loop`` 这类 Mako 渲染期才注入的特殊对象名。
+    MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset()
+
     RERUN_INDEX_OFFSET = 0
 
     # 当字符串是纯mako字符串时，是否自动渲染成对象，默认还是会渲染成字符串

--- a/bamboo_engine/template/template.py
+++ b/bamboo_engine/template/template.py
@@ -175,6 +175,24 @@ class Template:
             except Exception:
                 logger.exception("{} safety check error.".format(tpl))
                 continue
+            # 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``）。off 模式下保持
+            # 历史行为；warn 模式只打日志；enforce 模式命中即按 SingleLineNodeVisitor
+            # 风格 inert 掉这一段模板（``logger.warning + continue``）。
+            whitelist_mode = getattr(Settings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", "off")
+            if whitelist_mode in ("warn", "enforce"):
+                allowed_names = mako_safety.build_allowed_names(context)
+                try:
+                    check_mako_template_safety(
+                        tpl,
+                        mako_safety.WhitelistNameVisitor(allowed_names, mode=whitelist_mode),
+                        mako_safety.SingleLinCodeExtractor(),
+                    )
+                except ForbiddenMakoTemplateException as e:
+                    logger.warning("forbidden by whitelist: {}, exception: {}".format(tpl, e))
+                    continue
+                except Exception:
+                    logger.exception("{} whitelist check error.".format(tpl))
+                    continue
             resolved = Template._render_template(tpl, context)
             string = string.replace(tpl, resolved)
         return string

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -14,7 +14,8 @@ specific language governing permissions and limitations under the License.
 # Mako 安全工具
 
 
-from ast import NodeVisitor
+import ast
+import logging
 
 from mako import parsetree
 
@@ -22,7 +23,123 @@ from .mako_utils.code_extract import MakoNodeCodeExtractor
 from .mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
-class SingleLineNodeVisitor(NodeVisitor):
+logger = logging.getLogger("root")
+
+# 与 ``MAKO_SANDBOX_SHIELD_WORDS`` 不重叠的"安全内建函数"集合。
+# 用于白名单模式下默认放行的根标识符。
+# 不包含 ``bytes/bytearray/frozenset/memoryview/object/type/vars/getattr/...``
+# 等常出现在 shield 列表中的内建——它们即便能通过 AST 也会在渲染期被屏蔽成 ``None``，
+# 留在白名单里只会带来认知噪音。
+SAFE_BUILTIN_NAMES = frozenset(
+    {
+        "True",
+        "False",
+        "None",
+        # 类型构造（不会构造危险对象）
+        "bool",
+        "int",
+        "float",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        # 数学 / 长度
+        "abs",
+        "round",
+        "pow",
+        "sum",
+        "min",
+        "max",
+        "len",
+        # 序列
+        "range",
+        "slice",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        # 逻辑
+        "all",
+        "any",
+    }
+)
+
+# Mako 在渲染期会向模板命名空间注入的保留对象名，用户模板里出现这些名字时
+# 极大概率是在尝试触达模板内部对象（``self.module.cache.util.os...`` SSTI 链路）。
+# 对它们直接拒绝，可以堵住绝大多数 namespace 链式 RCE 路径。
+MAKO_RESERVED_NAMESPACES = frozenset(
+    {
+        "self",
+        "context",
+        "local",
+        "parent",
+        "next",
+        "caller",
+        "pageargs",
+        "UNDEFINED",
+        "STOP_RENDERING",
+    }
+)
+
+# attr 链路上一旦出现下列名字就立刻拒绝。
+#
+# 根 ``Name`` 白名单只能防"未授权根标识符"，挡不住通过白名单根名（如 ``os``、``datetime``、
+# ``re``）反向触达危险模块的链路：
+#
+# * ``${os.path.os.popen(...)}``        — ``os.path`` 内部 ``import os``
+# * ``${datetime.sys.modules['os']...}`` — ``datetime`` 内部 ``import sys``
+# * ``${re.enum.sys.modules['os']...}``  — ``re`` 重新 export ``enum``，``enum`` 内 ``import sys``
+#
+# 所有这些链路都需要 attr 链上出现 ``os / sys / subprocess / shutil / ctypes / socket /
+# builtins / modules`` 之一，或调用 ``popen / system / exec* / spawn* / fork*`` 之一。
+# 直接把 attr 名拉黑，就能切掉公共必经路径。这是纵深防御里的"任何路径都不该带这些字"，
+# 不是替代根名白名单。
+DANGEROUS_ATTR_NAMES = frozenset(
+    {
+        # 直接拿到危险模块对象
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "ctypes",
+        "socket",
+        "_thread",
+        "threading",
+        "builtins",
+        "__builtins__",
+        # 通过模块字典反向触达任意已导入模块
+        "modules",
+        # 进程 / 文件描述符相关原语（即便有人未来误把 ``os`` 加进白名单，也再加一层）
+        "popen",
+        "popen2",
+        "popen3",
+        "popen4",
+        "system",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "kill",
+    }
+)
+
+
+class SingleLineNodeVisitor(ast.NodeVisitor):
     """
     遍历语法树节点，遇到魔术方法使用或 import 时，抛出异常
     """
@@ -53,3 +170,161 @@ class SingleLinCodeExtractor(MakoNodeCodeExtractor):
             return None
         else:
             raise ForbiddenMakoTemplateException("Unsupported node: [{}]".format(node.__class__.__name__))
+
+
+def _deformat_var_key(key):
+    """``${name}`` -> ``name``；其它 key 原样返回。"""
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def build_allowed_names(context, *, extra=()):
+    """根据当前渲染 context 与全局 ``Settings`` 计算白名单的根标识符集合。
+
+    包含：
+      * ``context`` 中的键（``${name}`` 形式自动 deformat）
+      * ``Settings.MAKO_SANDBOX_IMPORT_MODULES`` 中每个 alias 的首段
+        （例：``os.path`` → ``os``）
+      * :data:`SAFE_BUILTIN_NAMES`
+      * ``Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST``
+      * 调用方传入的 ``extra``
+    """
+    # 局部 import 避免循环依赖（``Settings`` 在 ``bamboo_engine.config``）。
+    from bamboo_engine.config import Settings
+
+    allowed = set(SAFE_BUILTIN_NAMES)
+
+    for key in context.keys() if context else ():
+        allowed.add(_deformat_var_key(key))
+
+    import_modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    for alias in import_modules.values():
+        if alias:
+            allowed.add(alias.split(".", 1)[0])
+
+    extra_whitelist = getattr(Settings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", None) or ()
+    allowed.update(extra_whitelist)
+    allowed.update(extra)
+
+    return allowed
+
+
+class WhitelistNameVisitor(ast.NodeVisitor):
+    """根标识符白名单 visitor。
+
+    只允许 Load 语义的 ``Name`` 节点引用 ``allowed_names`` 中的标识符；其余一律按
+    ``mode`` 处理：
+
+      * ``warn``：调用 ``on_violation`` / 打 warning 日志，**不抛异常**（灰度模式）。
+      * ``enforce``：抛 :exc:`ForbiddenMakoTemplateException`，由
+        :func:`bamboo_engine.utils.mako_utils.checker.check_mako_template_safety` 捕获。
+
+    本 visitor 还显式拦截 :data:`MAKO_RESERVED_NAMESPACES` 中的标识符，
+    无论是否被传入 ``allowed_names`` 都会被拒，避免误把 ``self/context/...`` 加进
+    上下文导致 SSTI 链路被放行。
+
+    支持 ``ListComp / SetComp / DictComp / GeneratorExp / Lambda`` 引入的局部
+    绑定——这些临时变量会被压入作用域栈，在子树访问完后自动弹出。
+    """
+
+    def __init__(self, allowed_names, mode="enforce", on_violation=None):
+        if mode not in {"warn", "enforce"}:
+            raise ValueError("invalid whitelist mode: {}".format(mode))
+        self.allowed_names = set(allowed_names)
+        self.mode = mode
+        self.on_violation = on_violation
+        self.scope_stack = []
+
+    def _name_allowed(self, name):
+        if name in MAKO_RESERVED_NAMESPACES:
+            return False
+        if name in self.allowed_names:
+            return True
+        for scope in self.scope_stack:
+            if name in scope:
+                return True
+        return False
+
+    def _violate(self, name, reason):
+        msg = "name not in whitelist: {} ({})".format(name, reason)
+        if self.on_violation is not None:
+            try:
+                self.on_violation(name, reason)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("on_violation callback raised")
+        if self.mode == "enforce":
+            raise ForbiddenMakoTemplateException(msg)
+        logger.warning("[mako_whitelist] %s", msg)
+
+    @staticmethod
+    def _collect_targets(target, into):
+        if isinstance(target, ast.Name):
+            into.add(target.id)
+        elif isinstance(target, ast.Starred):
+            WhitelistNameVisitor._collect_targets(target.value, into)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                WhitelistNameVisitor._collect_targets(elt, into)
+
+    def visit_Name(self, node):
+        # Store / Del 上下文是赋值/删除目标，由 _enter_* 显式处理，跳过命名检查
+        if not isinstance(node.ctx, ast.Load):
+            return
+        if node.id in MAKO_RESERVED_NAMESPACES:
+            self._violate(node.id, "mako reserved namespace")
+            return
+        if not self._name_allowed(node.id):
+            self._violate(node.id, "not in whitelist")
+
+    def visit_Attribute(self, node):
+        # 单下划线 attr 拒绝：堵 ``context._with_template / context._kwargs`` 这类
+        # Python "半私有" 通道（双下划线已经在 ``SingleLineNodeVisitor`` 拦过，这里
+        # 顺手收紧成单下划线，覆盖更广）。
+        if node.attr.startswith("_"):
+            self._violate(node.attr, "private attribute")
+            return
+        # 危险 attr 名拒绝：堵 ``${os.path.os.popen(...)}`` /
+        # ``${datetime.sys.modules['os'].popen(...)}`` 类反向引用链路。
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            self._violate(node.attr, "dangerous attribute")
+            return
+        self.generic_visit(node)
+
+    def _enter_comprehension(self, node):
+        local = set()
+        for gen in node.generators:
+            self._collect_targets(gen.target, local)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()
+
+    def visit_ListComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_SetComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_DictComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_GeneratorExp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_Lambda(self, node):
+        local = set()
+        args = node.args
+        local.update(arg.arg for arg in args.args)
+        local.update(arg.arg for arg in args.kwonlyargs)
+        local.update(arg.arg for arg in getattr(args, "posonlyargs", ()) or ())
+        if args.vararg:
+            local.add(args.vararg.arg)
+        if args.kwarg:
+            local.add(args.kwarg.arg)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()

--- a/runtime/bamboo-pipeline/pipeline/core/data/expression.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/expression.py
@@ -141,6 +141,26 @@ class ConstantTemplate(object):
                 except Exception:
                     logger.exception("{} safety check error.".format(tpl))
                     continue
+                # 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``），延用引擎全局
+                # ``Settings`` 配置；off 时保持历史行为，warn 仅打日志，enforce 命中即
+                # 按 SingleLineNodeVisitor 风格 inert 掉这一段模板。
+                from bamboo_engine.config import Settings as _BambooSettings
+
+                whitelist_mode = getattr(_BambooSettings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", "off")
+                if whitelist_mode in ("warn", "enforce"):
+                    allowed_names = mako_safety.build_allowed_names(value_maps)
+                    try:
+                        check_mako_template_safety(
+                            tpl,
+                            mako_safety.WhitelistNameVisitor(allowed_names, mode=whitelist_mode),
+                            mako_safety.SingleLinCodeExtractor(),
+                        )
+                    except ForbiddenMakoTemplateException as e:
+                        logger.warning("forbidden by whitelist: {}, exception: {}".format(tpl, e))
+                        continue
+                    except Exception:
+                        logger.exception("{} whitelist check error.".format(tpl))
+                        continue
             resolved = ConstantTemplate.resolve_template(tpl, value_maps)
             string = string.replace(tpl, resolved)
         return string

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -10,8 +10,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-from ast import NodeVisitor
+import ast
+import logging
 
 from mako import parsetree
 
@@ -19,7 +19,99 @@ from pipeline.utils.mako_utils.code_extract import MakoNodeCodeExtractor
 from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
-class SingleLineNodeVisitor(NodeVisitor):
+logger = logging.getLogger("root")
+
+# 与 ``MAKO_SANDBOX_SHIELD_WORDS`` 不重叠的"安全内建函数"集合，详见
+# ``bamboo_engine.utils.mako_safety.SAFE_BUILTIN_NAMES``。
+SAFE_BUILTIN_NAMES = frozenset(
+    {
+        "True",
+        "False",
+        "None",
+        "bool",
+        "int",
+        "float",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        "abs",
+        "round",
+        "pow",
+        "sum",
+        "min",
+        "max",
+        "len",
+        "range",
+        "slice",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        "all",
+        "any",
+    }
+)
+
+# Mako 渲染期保留命名空间，详见 ``bamboo_engine.utils.mako_safety.MAKO_RESERVED_NAMESPACES``。
+MAKO_RESERVED_NAMESPACES = frozenset(
+    {
+        "self",
+        "context",
+        "local",
+        "parent",
+        "next",
+        "caller",
+        "pageargs",
+        "UNDEFINED",
+        "STOP_RENDERING",
+    }
+)
+
+# attr 链路危险字段，详见 ``bamboo_engine.utils.mako_safety.DANGEROUS_ATTR_NAMES``。
+DANGEROUS_ATTR_NAMES = frozenset(
+    {
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "ctypes",
+        "socket",
+        "_thread",
+        "threading",
+        "builtins",
+        "__builtins__",
+        "modules",
+        "popen",
+        "popen2",
+        "popen3",
+        "popen4",
+        "system",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "kill",
+    }
+)
+
+
+class SingleLineNodeVisitor(ast.NodeVisitor):
     """
     遍历语法树节点，遇到魔术方法使用或 import 时，抛出异常
     """
@@ -50,3 +142,139 @@ class SingleLinCodeExtractor(MakoNodeCodeExtractor):
             return None
         else:
             raise ForbiddenMakoTemplateException("Unsupported node: [{}]".format(node.__class__.__name__))
+
+
+def _deformat_var_key(key):
+    """``${name}`` -> ``name``；其它 key 原样返回。"""
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def build_allowed_names(context, *, extra=()):
+    """legacy 模板渲染白名单根标识符集合。
+
+    与 ``bamboo_engine.utils.mako_safety.build_allowed_names`` 行为一致：
+    复用 ``bamboo_engine.config.Settings`` 上的 ``MAKO_SANDBOX_IMPORT_MODULES /
+    MAKO_TEMPLATE_NAME_EXTRA_WHITELIST`` 配置，避免接入方维护两套白名单源。
+    """
+    from bamboo_engine.config import Settings
+
+    allowed = set(SAFE_BUILTIN_NAMES)
+
+    for key in context.keys() if context else ():
+        allowed.add(_deformat_var_key(key))
+
+    import_modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    for alias in import_modules.values():
+        if alias:
+            allowed.add(alias.split(".", 1)[0])
+
+    extra_whitelist = getattr(Settings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", None) or ()
+    allowed.update(extra_whitelist)
+    allowed.update(extra)
+
+    return allowed
+
+
+class WhitelistNameVisitor(ast.NodeVisitor):
+    """legacy 渲染路径用的白名单 visitor，行为对齐
+    ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor``。
+    """
+
+    def __init__(self, allowed_names, mode="enforce", on_violation=None):
+        if mode not in {"warn", "enforce"}:
+            raise ValueError("invalid whitelist mode: {}".format(mode))
+        self.allowed_names = set(allowed_names)
+        self.mode = mode
+        self.on_violation = on_violation
+        self.scope_stack = []
+
+    def _name_allowed(self, name):
+        if name in MAKO_RESERVED_NAMESPACES:
+            return False
+        if name in self.allowed_names:
+            return True
+        for scope in self.scope_stack:
+            if name in scope:
+                return True
+        return False
+
+    def _violate(self, name, reason):
+        msg = "name not in whitelist: {} ({})".format(name, reason)
+        if self.on_violation is not None:
+            try:
+                self.on_violation(name, reason)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("on_violation callback raised")
+        if self.mode == "enforce":
+            raise ForbiddenMakoTemplateException(msg)
+        logger.warning("[mako_whitelist] %s", msg)
+
+    @staticmethod
+    def _collect_targets(target, into):
+        if isinstance(target, ast.Name):
+            into.add(target.id)
+        elif isinstance(target, ast.Starred):
+            WhitelistNameVisitor._collect_targets(target.value, into)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                WhitelistNameVisitor._collect_targets(elt, into)
+
+    def visit_Name(self, node):
+        if not isinstance(node.ctx, ast.Load):
+            return
+        if node.id in MAKO_RESERVED_NAMESPACES:
+            self._violate(node.id, "mako reserved namespace")
+            return
+        if not self._name_allowed(node.id):
+            self._violate(node.id, "not in whitelist")
+
+    def visit_Attribute(self, node):
+        # 与新引擎 ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor.visit_Attribute``
+        # 保持一致：单下划线前缀 + 危险 attr 名一律拒绝，堵反向引用 SSTI 链路。
+        if node.attr.startswith("_"):
+            self._violate(node.attr, "private attribute")
+            return
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            self._violate(node.attr, "dangerous attribute")
+            return
+        self.generic_visit(node)
+
+    def _enter_comprehension(self, node):
+        local = set()
+        for gen in node.generators:
+            self._collect_targets(gen.target, local)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()
+
+    def visit_ListComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_SetComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_DictComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_GeneratorExp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_Lambda(self, node):
+        local = set()
+        args = node.args
+        local.update(arg.arg for arg in args.args)
+        local.update(arg.arg for arg in args.kwonlyargs)
+        local.update(arg.arg for arg in getattr(args, "posonlyargs", ()) or ())
+        if args.vararg:
+            local.add(args.vararg.arg)
+        if args.kwarg:
+            local.add(args.kwarg.arg)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -214,3 +214,96 @@ class TestConstantTemplate(TestCase):
             self.assertEqual(expression.ConstantTemplate(at).resolve_data({}), at)
 
         sandbox.SANDBOX = sandbox_copy
+
+
+class TestMakoNameWhitelist(TestCase):
+    """``MAKO_TEMPLATE_NAME_WHITELIST_MODE`` 在 legacy ``ConstantTemplate`` 上的覆盖。
+
+    新引擎 ``bamboo_engine.template.Template`` 与 legacy ``ConstantTemplate`` 走的是
+    各自独立的渲染路径。两边都需要白名单 visitor，否则只挡一边等于没挡。
+    """
+
+    def setUp(self):
+        from bamboo_engine.config import Settings as BambooSettings
+
+        self._BambooSettings = BambooSettings
+        self._original_mode = BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE
+        self._original_extra = BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
+    def tearDown(self):
+        self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = self._original_mode
+        self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = self._original_extra
+
+    def _set_mode(self, mode, extra=()):
+        self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
+        self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
+
+    def test_off_mode_keeps_legacy_behavior(self):
+        self._set_mode("off")
+        payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertIn("OFF", rendered)
+
+    def test_enforce_blocks_self_module(self):
+        self._set_mode("enforce")
+        payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertEqual(rendered, payload)
+
+    def test_dangerous_attr_chain_blocked(self):
+        """根 Name 是白名单内的导入模块，但 attr 链上出现 os/sys/modules/popen 等危险字段也必须拦。"""
+        self._set_mode("enforce")
+        original_imports = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {
+            "datetime": "datetime",
+            "re": "re",
+            "os.path": "os.path",
+        }
+        try:
+            payloads = [
+                '${os.path.os.popen("echo PWNED").read()}',
+                '${os.path.genericpath.os.popen("echo PWNED").read()}',
+                '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+                '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+            ]
+            for p in payloads:
+                with self.subTest(payload=p):
+                    rendered = expression.ConstantTemplate(p).resolve_data({})
+                    self.assertEqual(rendered, p)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+    def test_single_underscore_attr_blocked(self):
+        self._set_mode("enforce")
+        for p in [
+            "${context._kwargs}",
+            "${context._with_template}",
+            "${obj._secret}",
+        ]:
+            with self.subTest(payload=p):
+                rendered = expression.ConstantTemplate(p).resolve_data({"obj": object()})
+                self.assertEqual(rendered, p)
+
+    def test_business_patterns_still_render(self):
+        self._set_mode("enforce")
+        cases = [
+            ("${name.upper()}", {"name": "abc"}, "ABC"),
+            ("${[x * 2 for x in items]}", {"items": [1, 2, 3]}, "[2, 4, 6]"),
+            ("${(lambda y: y + 1)(seed)}", {"seed": 4}, "5"),
+            ("${len(items)}", {"items": [1, 2]}, "2"),
+        ]
+        for tpl, ctx, expected in cases:
+            with self.subTest(tpl=tpl):
+                self.assertEqual(expression.ConstantTemplate(tpl).resolve_data(ctx), expected)
+
+    def test_extra_whitelist_names(self):
+        self._set_mode("enforce", extra=("_loop", "_system"))
+        # 单 token 模板：直接返回 context 中原始值
+        self.assertEqual(expression.ConstantTemplate("${_loop}").resolve_data({"_loop": 3}), 3)
+        # 表达式：走白名单 visitor，``_loop`` 在 extra 白名单中放行
+        self.assertEqual(expression.ConstantTemplate("${_loop + 1}").resolve_data({"_loop": 4}), "5")
+
+    def test_unknown_root_name_blocked(self):
+        self._set_mode("enforce")
+        payload = "${secret_var}"
+        self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -130,3 +130,168 @@ def test_mako_attack():
     ]
     for at in attack_templates:
         assert Template(at).render({}) == at
+
+
+# ---------------------------------------------------------------------------
+# 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``）。这套机制覆盖：
+#
+# 1. ``self / context / local / parent / next / caller / pageargs`` 等 Mako
+#    渲染期注入的保留命名空间（堵 ``self.module.cache.util.os.popen`` SSTI 链路）。
+# 2. attr 链路上的危险字段 / 单下划线 attr，堵 ``${os.path.os.popen(...)}``、
+#    ``${datetime.sys.modules['os']...}``、``${context._kwargs}`` 这类反向引用。
+# 3. 业务正常用法（字符串方法、``datetime.datetime.now().strftime(...)``、
+#    ``os.path.join`` / 列表推导 / lambda）必须照常渲染。
+# ---------------------------------------------------------------------------
+
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture
+def whitelist_mode():
+    """在 ``Settings`` 上切换 ``MAKO_TEMPLATE_NAME_WHITELIST_MODE``，测试结束后还原。"""
+    original_mode = Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE
+    original_extra = Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
+    def _set(mode, extra=()):
+        Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
+        Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
+
+    try:
+        yield _set
+    finally:
+        Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = original_mode
+        Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = original_extra
+
+
+def test_mako_self_module_namespace_executes_when_whitelist_off(whitelist_mode):
+    """白名单关闭时，``self.module.*`` SSTI 链路是确实存在的——这是回归基线。"""
+    whitelist_mode("off")
+    payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
+    rendered = Template(payload).render({})
+    assert "OFF" in rendered, "off 模式下白名单未启用，PoC 应仍执行"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${self.module.cache.util.os.popen("echo PWNED").read()}',
+        "${context.lookup}",
+        "${local.something}",
+        "${parent.foo}",
+        "${caller.body()}",
+        "${pageargs.x}",
+    ],
+)
+def test_mako_whitelist_blocks_reserved_namespaces(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    assert Template(payload).render({}) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # ``os.path`` 内部 ``import os``：os.path.os is os
+        '${os.path.os.popen("echo PWNED").read()}',
+        # 嵌套子模块：os.path.genericpath.os 同样指向真实 os
+        '${os.path.genericpath.os.popen("echo PWNED").read()}',
+        # ``datetime`` import 了 sys，再走 sys.modules 拿 os
+        '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+        # ``re`` 重新 export ``enum``，``enum`` 内部 import sys
+        '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+        # 直接调用 popen / system 也要拦
+        '${os.path.os.system("echo PWNED")}',
+    ],
+)
+def test_mako_whitelist_blocks_dangerous_attr_chain(whitelist_mode, payload):
+    """白名单根名（``os / datetime / re``）必须挡得住 attr 链反向引用。"""
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "re": "re",
+        "os.path": "os.path",
+    }
+    try:
+        rendered = Template({"x": payload}).render({})
+        # ``rendered["x"] == payload`` 已经证明被拦后原样回显——不再用字面 PWNED 字符串
+        # 二次断言（payload 本身就含 ``echo PWNED``，字符串包含关系无法区分"被拦的原文"
+        # 和"被执行的输出"）。
+        assert rendered["x"] == payload
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${context._kwargs}",
+        "${context._with_template}",
+        "${context._data}",
+        "${obj._secret}",
+        "${obj.public._private}",
+    ],
+)
+def test_mako_whitelist_blocks_single_underscore_attr(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    rendered = Template({"x": payload}).render({"obj": object()})
+    assert rendered["x"] == payload
+
+
+def test_mako_whitelist_allows_business_patterns(whitelist_mode):
+    whitelist_mode("enforce")
+    cases = [
+        ("${name.upper()}", {"name": "abc"}, "ABC"),
+        ("${name.split('-')}", {"name": "a-b-c"}, "['a', 'b', 'c']"),
+        ("${[x * 2 for x in items]}", {"items": [1, 2, 3]}, "[2, 4, 6]"),
+        ("${(lambda y: y + 1)(seed)}", {"seed": 4}, "5"),
+        ("${a if a else 'default'}", {"a": ""}, "default"),
+        ("${len(items)}", {"items": [1, 2, 3]}, "3"),
+    ]
+    for tpl, ctx, expected in cases:
+        assert Template(tpl).render(ctx) == expected
+
+
+def test_mako_whitelist_allows_imported_modules(whitelist_mode):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "os.path": "os.path",
+    }
+    try:
+        # os.path.join 仍可用（join 不在 DANGEROUS_ATTR_NAMES）
+        assert Template('${os.path.join("a", "b")}').render({}) == "a/b"
+        # datetime.datetime.now().strftime 链路全程合法
+        out = Template('${datetime.datetime.now().strftime("%Y")}').render({})
+        assert len(out) == 4 and out.isdigit()
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+def test_mako_whitelist_extra_names_allowed(whitelist_mode):
+    whitelist_mode("enforce", extra=("_loop", "_system"))
+    out = Template("${_loop}").render({"_loop": 7})
+    # 单 token 模板会直接返回 context 中的原始值；当不存在时则按白名单评估表达式。
+    assert out == 7
+    assert Template("${_loop + 1}").render({"_loop": 2}) == "3"
+
+
+def test_mako_whitelist_unknown_root_name_is_blocked(whitelist_mode):
+    whitelist_mode("enforce")
+    payload = "${secret_var}"
+    assert Template(payload).render({}) == payload
+
+
+def test_mako_whitelist_warn_mode_does_not_block_but_logs(whitelist_mode, caplog):
+    whitelist_mode("warn")
+    payload = "${self.module}"
+    with caplog.at_level("WARNING"):
+        # warn 模式下 visitor 自身不抛——但 Mako 渲染保留命名空间 ``self.module``
+        # 时仍会在渲染层失败，因此结果取决于运行期；本测试只确认日志被打到。
+        try:
+            Template(payload).render({})
+        except Exception:
+            pass
+    assert any("name not in whitelist" in r.getMessage() or "self" in r.getMessage() for r in caplog.records)
+


### PR DESCRIPTION
## Summary

把 `release/prep-4.0-lts` 上已合入的四个 Mako SSTI 安全补丁（515a87b / 6ddade1 / f1ad9c7 / ed1063c）压成单个 commit 移植到 `master` / 3.29 LTS，并随之 bump 版本：

- `bamboo-engine`   : 2.11.1 → **2.11.2**
- `bamboo-pipeline` : 3.29.7 → **3.29.8**

下游 `bk-flow / bk-sops` 等接入方需要这次发版才能在 3.29 LTS 链路启用白名单。

## 漏洞背景

现有 `MAKO_SANDBOX_SHIELD_WORDS` + `SingleLineNodeVisitor`（仅拦 `__` dunder + `import`）不足以挡住下面这些已知 PoC：

```mako
${self.module.cache.util.os.popen("id").read()}        ## Mako 内部命名空间反向引用
${os.path.os.popen("id").read()}                       ## os.path 内部 import os
${os.path.genericpath.os.popen("id").read()}           ## 嵌套子模块同样指向真实 os
${datetime.sys.modules["os"].popen("id").read()}       ## datetime 内部 import sys
${re.enum.sys.modules["os"].popen("id").read()}        ## re.enum 内部 import sys
${context._kwargs}                                     ## Mako Context 半私有通道
```

它们都是 **白名单根名 → 任意 attr 链** 的反向引用，单纯加 shield word 拦不住。

## 修复

### 1. 根标识符白名单（`WhitelistNameVisitor` + `build_allowed_names`）

只放行下列根 Name：

- `context` / `value_maps` 中的 key（自动 deformat `${name}` 形式）
- `Settings.MAKO_SANDBOX_IMPORT_MODULES` 每个 alias 的首段（如 `os.path` → `os`）
- `SAFE_BUILTIN_NAMES`（与 `MAKO_SANDBOX_SHIELD_WORDS` 互不相交的安全 builtin 子集）
- `Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST`（接入方用于 `_system / _loop` 等渲染期注入对象）
- 推导式 / `lambda` 引入的局部绑定

显式拒绝 `MAKO_RESERVED_NAMESPACES`（`self / context / local / parent / next / caller / pageargs / UNDEFINED / STOP_RENDERING`）作为根 Name —— 即便有人把 `self` 加进 context 也挡得住。

### 2. attr 链路收紧

`WhitelistNameVisitor.visit_Attribute` 现在做两件事：

- 拒绝任意 `_` 前缀 attr（堵 `context._with_template / context._kwargs` 等 Mako Context 半私有通道；`__` 前缀仍由旧的 `SingleLineNodeVisitor` 拦截，这里收紧成单下划线，覆盖更广）。
- 拒绝命中 `DANGEROUS_ATTR_NAMES` 的 attr（`os / sys / subprocess / shutil / ctypes / socket / builtins / modules` + `popen / system / exec* / spawn* / fork* / kill`），堵反向引用模块字典 + 进程原语链路。

### 3. 配置开关

- `Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE` 支持 `off / warn / enforce`，**默认 `off` 保持兼容**，由接入方按节奏切换。
- `Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST` 让接入方声明 `_system / _loop` 等渲染期才注入的特殊根名。

### 4. 双路径同步

`bamboo_engine.template.Template._render_string` 与 legacy `pipeline.core.data.expression.ConstantTemplate.resolve_string` 各自挂上 `WhitelistNameVisitor`；只挡一边等于没挡。

## 兼容性

- **默认 `off`**，对现有部署零行为变化。接入方需要在自己的 Django settings 里显式 `BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = "warn"` 灰度若干天再切 `enforce`。
- `runtime/bamboo-pipeline/poetry.lock` 的 `content-hash` 未变（仅 bamboo-engine 自引用版本号 2.11.1 → 2.11.2，pyproject 依赖列表无变化）。

## 接入示例

```python
# config/default.py
from bamboo_engine.config import Settings as BambooSettings

BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = "enforce"  # off / warn / enforce
BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset({"_system", "_loop", "_inner_loop"})
```

## Test plan

- [x] 新引擎 `tests/template/test_template.py`：29 项全过（含 5 条 attr-chain SSTI、6 条 reserved-namespace、3 条 `_` 前缀 attr、6 条业务 pattern、1 条 `warn` 模式日志、1 条 `off` 模式回归）。
- [x] Legacy `runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py`：25 项 + 11 subTest 全过。
- [x] 端到端 PoC 烟测（`enforce` 模式）：6 / 6 已知 SSTI payload 全部 inert 回显。
- [x] 业务用例烟测：`os.path.join` / `datetime.datetime.now().strftime` / 字符串方法 / 列表推导 / lambda 全部正常渲染。

## 4.0 LTS 已落地的对应改动

`release/prep-4.0-lts` 上已经分四个 commit 落地（`feat → feat (legacy port) → test → fix (attr chain hardening)`），等待发布。这次 `master` 是把那四个 commit 合并成单个回填 commit。
