### PR TITLE
fix(mako): 在最新 master 上集成 Mako filter 加固（与根标识符白名单防护并存）

### DIFF
--- a/bamboo_engine/config.py
+++ b/bamboo_engine/config.py
@@ -23,6 +23,7 @@ class Settings:
 
     MAKO_SANDBOX_SHIELD_WORDS = [
         "ascii",
+        "breakpoint",
         "bytearray",
         "bytes",
         "callable",
@@ -35,6 +36,7 @@ class Settings:
         "exec",
         "eval",
         "filter",
+        "format",
         "frozenset",
         "getattr",
         "globals",

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -16,6 +16,7 @@ specific language governing permissions and limitations under the License.
 
 import ast
 import logging
+import re
 
 from mako import parsetree
 
@@ -138,6 +139,10 @@ DANGEROUS_ATTR_NAMES = frozenset(
     }
 )
 
+FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
+SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
 
 class SingleLineNodeVisitor(ast.NodeVisitor):
     """
@@ -147,19 +152,58 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
     def __init__(self, *args, **kwargs):
         super(SingleLineNodeVisitor, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def _get_subscript_key(node):
+        slice_node = node.slice
+        if isinstance(slice_node, ast.Constant) and isinstance(slice_node.value, str):
+            return slice_node.value
+        if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):
+            return slice_node.s
+        return None
+
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Name(self, node):
         if node.id.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private method")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        subscript_key = self._get_subscript_key(node)
+        if isinstance(subscript_key, str) and subscript_key.startswith("__"):
+            raise ForbiddenMakoTemplateException("can not access private key")
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         raise ForbiddenMakoTemplateException("can not use import statement")
 
     def visit_ImportFrom(self, node):
         self.visit_Import(node)
+
+
+def validate_filter_args(filter_args):
+    for filter_arg in filter_args:
+        normalized_filter = filter_arg.strip()
+        if normalized_filter in SAFE_FILTERS:
+            continue
+        decode_filter_parts = normalized_filter.split(".")
+        if (
+            SAFE_DECODE_FILTER_PATTERN.match(normalized_filter)
+            and "__" not in normalized_filter
+            and not any(part.startswith("_") for part in decode_filter_parts[1:])
+        ):
+            continue
+        raise ForbiddenMakoTemplateException("unsupported filter expression: [{}]".format(normalized_filter))
 
 
 class SingleLinCodeExtractor(MakoNodeCodeExtractor):

--- a/bamboo_engine/utils/mako_utils/checker.py
+++ b/bamboo_engine/utils/mako_utils/checker.py
@@ -19,8 +19,17 @@ from mako import parsetree
 from mako.exceptions import MakoException
 from mako.lexer import Lexer
 
+from bamboo_engine.utils import mako_safety
+
 from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
+
+
+def validate_node_filters(node: parsetree.Node):
+    if hasattr(node, "escapes_code"):
+        mako_safety.validate_filter_args(node.escapes_code.args)
+    if hasattr(node, "filter_args"):
+        mako_safety.validate_filter_args(node.filter_args.args)
 
 
 def parse_template_nodes(
@@ -35,14 +44,15 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        code = code_extractor.extract(node)
-        if code is None:
-            continue
+        validate_node_filters(node)
 
-        ast_node = ast.parse(code, "<unknown>", "exec")
-        node_visitor.visit(ast_node)
+        code = code_extractor.extract(node)
+        if code is not None:
+            ast_node = ast.parse(code, "<unknown>", "exec")
+            node_visitor.visit(ast_node)
+
         if hasattr(node, "nodes"):
-            parse_template_nodes(node.nodes, node_visitor)
+            parse_template_nodes(node.nodes, node_visitor, code_extractor)
 
 
 def check_mako_template_safety(text: str, node_visitor: ast.NodeVisitor, code_extractor: MakoNodeCodeExtractor) -> bool:

--- a/bamboo_engine/utils/mako_utils/checker.py
+++ b/bamboo_engine/utils/mako_utils/checker.py
@@ -25,7 +25,9 @@ from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
 
 
-def validate_node_filters(node: parsetree.Node):
+def validate_node_filter_callables(node: parsetree.Node):
+    # Mako stores inline `${expr | ...}` filter callables in `escapes_code`;
+    # tag-level filters use `filter_args`. Both are executed by create_filter_callable().
     if hasattr(node, "escapes_code"):
         mako_safety.validate_filter_args(node.escapes_code.args)
     if hasattr(node, "filter_args"):
@@ -44,7 +46,7 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        validate_node_filters(node)
+        validate_node_filter_callables(node)
 
         code = code_extractor.extract(node)
         if code is not None:

--- a/runtime/bamboo-pipeline/pipeline/conf/default_settings.py
+++ b/runtime/bamboo-pipeline/pipeline/conf/default_settings.py
@@ -94,7 +94,53 @@ EXPIRED_TASK_CLEAN_NUM_LIMIT = getattr(settings, "EXPIRED_TASK_CLEAN_NUM_LIMIT",
 TASK_EXPIRED_MONTH = getattr(settings, "TASK_EXPIRED_MONTH", 6)
 
 # MAKO sandbox config
-MAKO_SANDBOX_SHIELD_WORDS = getattr(settings, "MAKO_SANDBOX_SHIELD_WORDS", [])
+# 默认屏蔽所有可被用于 SSTI 链路的内建可调用名字（getattr/eval/exec/open/type/__import__ 等）。
+# 这是一份与 ``bamboo_engine.config.Settings.MAKO_SANDBOX_SHIELD_WORDS`` 保持同步的安全兜底，
+# 任何未显式设置 ``MAKO_SANDBOX_SHIELD_WORDS`` 的 Django 宿主也能开箱即得到屏蔽。
+DEFAULT_MAKO_SANDBOX_SHIELD_WORDS = [
+    "ascii",
+    "breakpoint",
+    "bytearray",
+    "bytes",
+    "callable",
+    "chr",
+    "classmethod",
+    "compile",
+    "delattr",
+    "dir",
+    "divmod",
+    "exec",
+    "eval",
+    "filter",
+    "format",
+    "frozenset",
+    "getattr",
+    "globals",
+    "hasattr",
+    "hash",
+    "help",
+    "id",
+    "input",
+    "isinstance",
+    "issubclass",
+    "iter",
+    "locals",
+    "map",
+    "memoryview",
+    "next",
+    "object",
+    "open",
+    "print",
+    "property",
+    "repr",
+    "setattr",
+    "staticmethod",
+    "super",
+    "type",
+    "vars",
+    "__import__",
+]
+MAKO_SANDBOX_SHIELD_WORDS = getattr(settings, "MAKO_SANDBOX_SHIELD_WORDS", DEFAULT_MAKO_SANDBOX_SHIELD_WORDS)
 MAKO_SANDBOX_IMPORT_MODULES = getattr(settings, "MAKO_SANDBOX_IMPORT_MODULES", {})
 MAKO_SAFETY_CHECK = getattr(settings, "MAKO_SAFETY_CHECK", True)
 

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 """
 import ast
 import logging
+import re
 
 from mako import parsetree
 
@@ -110,6 +111,10 @@ DANGEROUS_ATTR_NAMES = frozenset(
     }
 )
 
+FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
+SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
 
 class SingleLineNodeVisitor(ast.NodeVisitor):
     """
@@ -119,19 +124,67 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
     def __init__(self, *args, **kwargs):
         super(SingleLineNodeVisitor, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def _get_subscript_key(node):
+        slice_node = node.slice
+        if isinstance(slice_node, ast.Constant) and isinstance(slice_node.value, str):
+            return slice_node.value
+        if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):
+            return slice_node.s
+        return None
+
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Name(self, node):
         if node.id.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private method")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        subscript_key = self._get_subscript_key(node)
+        if isinstance(subscript_key, str) and subscript_key.startswith("__"):
+            raise ForbiddenMakoTemplateException("can not access private key")
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         raise ForbiddenMakoTemplateException("can not use import statement")
 
     def visit_ImportFrom(self, node):
         self.visit_Import(node)
+
+
+def validate_filter_args(filter_args):
+    """对 ``${expr | filter}`` 与 tag-level ``filter=`` 的 filter callable 做白名单校验。
+
+    Mako 在渲染期会把 filter 表达式作为 Python 代码 ``eval`` 出 callable，因此必须在
+    parse 阶段就拒绝任意 Python 表达式，否则攻击者可以通过 ``(side_effect() or str)``
+    这种 filter 表达式绕过主表达式上的 AST 检查。
+    """
+
+    for filter_arg in filter_args:
+        normalized_filter = filter_arg.strip()
+        if not normalized_filter:
+            continue
+        if normalized_filter in SAFE_FILTERS:
+            continue
+        decode_filter_parts = normalized_filter.split(".")
+        if (
+            SAFE_DECODE_FILTER_PATTERN.match(normalized_filter)
+            and "__" not in normalized_filter
+            and not any(part.startswith("_") for part in decode_filter_parts[1:])
+        ):
+            continue
+        raise ForbiddenMakoTemplateException("unsupported filter expression: [{}]".format(normalized_filter))
 
 
 class SingleLinCodeExtractor(MakoNodeCodeExtractor):

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -16,8 +16,10 @@ import datetime
 
 from django.test import TestCase
 
-from pipeline.core.data import expression, sandbox
+from pipeline.core.data import expression, mako_safety, sandbox
 from pipeline.core.data.expression import format_constant_key, deformat_constant_key
+from pipeline.utils.mako_utils.checker import check_mako_template_safety
+from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
 class TestConstantTemplate(TestCase):
@@ -57,10 +59,16 @@ class TestConstantTemplate(TestCase):
 
     def test_resolve_template_with_curly_braces(self):
         cons_tmpl = expression.ConstantTemplate("")
-        one_template = '${"test_{}".format(a)}'
-        self.assertEqual(cons_tmpl.resolve_string(one_template, {"a": "1"}), "test_1")
-        ano_template = '${f"test_{a}"}'
-        self.assertEqual(cons_tmpl.resolve_template(ano_template, {"a": "2"}), "test_2")
+        # ``.format(...)`` / ``.format_map(...)`` 在 mako 模板里被显式禁用以阻断
+        # ``${"{0.__class__}".format("")}`` 这一类 dunder lookup 绕过；走 ``resolve_string``
+        # 时模板会被原样回显。
+        format_attr_template = '${"test_{}".format(a)}'
+        self.assertEqual(cons_tmpl.resolve_string(format_attr_template, {"a": "1"}), format_attr_template)
+        # 合法的等价写法：% 格式化与 f-string 仍正常渲染。
+        percent_template = '${"test_%s" % a}'
+        self.assertEqual(cons_tmpl.resolve_string(percent_template, {"a": "1"}), "test_1")
+        fstring_template = '${f"test_{a}"}'
+        self.assertEqual(cons_tmpl.resolve_template(fstring_template, {"a": "2"}), "test_2")
 
     def test_resolve_string(self):
         cons_tmpl = expression.ConstantTemplate("")
@@ -163,6 +171,7 @@ class TestConstantTemplate(TestCase):
         sandbox_copy = copy.deepcopy(sandbox.SANDBOX)
         shield_words = [
             "ascii",
+            "breakpoint",
             "bytearray",
             "bytes",
             "callable",
@@ -175,6 +184,7 @@ class TestConstantTemplate(TestCase):
             "exec",
             "eval",
             "filter",
+            "format",
             "frozenset",
             "getattr",
             "globals",
@@ -312,3 +322,109 @@ class TestMakoNameWhitelist(TestCase):
         self._set_mode("enforce")
         payload = "${secret_var}"
         self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+
+
+class TestMakoSafetyHardening(TestCase):
+    """
+    与 ``tests/template/test_template.py`` 平行的 bamboo-pipeline runtime 侧回归。
+
+    PR #265 把 filter callable / tag-level filter 校验加进了 ``bamboo_engine.utils.mako_safety``，
+    bamboo-pipeline runtime 这一路（``pipeline.core.data.mako_safety``）是独立的一份代码，
+    本测试类确保这边的实现具备同样的拦截能力。
+    """
+
+    def _assert_forbidden(self, payload):
+        with self.assertRaises(ForbiddenMakoTemplateException):
+            check_mako_template_safety(
+                payload,
+                mako_safety.SingleLineNodeVisitor(),
+                mako_safety.SingleLinCodeExtractor(),
+            )
+
+    def _assert_allowed(self, payload):
+        check_mako_template_safety(
+            payload,
+            mako_safety.SingleLineNodeVisitor(),
+            mako_safety.SingleLinCodeExtractor(),
+        )
+
+    def test_filter_callable_with_side_effect_is_blocked(self):
+        self._assert_forbidden("${'x'|((side_effect() or str))}")
+
+    def test_filter_with_dunder_chain_is_blocked(self):
+        self._assert_forbidden("${'x'|().__class__.__bases__[0].__subclasses__}")
+
+    def test_filter_list_with_malicious_item_is_blocked(self):
+        self._assert_forbidden("${'x'|h, (side_effect() or str)}")
+
+    def test_decode_filter_with_dunder_is_blocked(self):
+        self._assert_forbidden("${'x'|decode.__class__}")
+
+    def test_tag_level_expression_filter_is_blocked(self):
+        self._assert_forbidden('<%page expression_filter="(side_effect() or str)"/>${name}')
+
+    def test_tag_level_def_filter_is_blocked(self):
+        payload = '<%def name="r(x)" filter="(side_effect() or str)">${x}</%def>${r("x")}'
+        self._assert_forbidden(payload)
+
+    def test_tag_level_block_filter_is_blocked(self):
+        self._assert_forbidden('<%block filter="(side_effect() or str)">x</%block>')
+
+    def test_tag_level_text_filter_is_blocked(self):
+        self._assert_forbidden('<%text filter="(side_effect() or str)">x</%text>')
+
+    def test_format_attribute_call_is_blocked(self):
+        self._assert_forbidden('${"{0.__class__}".format("")}')
+
+    def test_format_map_attribute_call_is_blocked(self):
+        self._assert_forbidden('${"{value.__class__}".format_map({"value": ""})}')
+
+    def test_subscript_dunder_key_is_blocked(self):
+        self._assert_forbidden("${a['__class__']}")
+
+    def test_builtin_filters_remain_allowed(self):
+        for payload in [
+            "${' x ' | h}",
+            "${' x ' | trim}",
+            "${' x ' | h, trim}",
+            "${'x' | n}",
+            "${b'abc' | decode.utf8}",
+        ]:
+            with self.subTest(payload=payload):
+                self._assert_allowed(payload)
+
+    def test_latent_bypass_is_inert_under_complete_shield(self):
+        """以下 payload 能过 AST 检查（动态拼字符串 / Name 调用 / 内建调用），
+        必须依靠完整 shield 在渲染期保持 inert。
+        """
+        sandbox_copy = copy.deepcopy(sandbox.SANDBOX)
+        try:
+            sandbox._shield_words(
+                sandbox.SANDBOX,
+                [
+                    "getattr",
+                    "type",
+                    "vars",
+                    "format",
+                    "breakpoint",
+                    "dir",
+                    "object",
+                ],
+            )
+            payloads = [
+                "${getattr('', '__cl' + 'ass__')}",
+                (
+                    "${getattr(getattr(getattr('', '__cl' + 'ass__'), '__ba' + 'se__'),"
+                    " '__sub' + 'classes__')()}"
+                ),
+                "${getattr('', dir(0)[0][0] + dir(0)[0][0] + 'class' + dir(0)[0][0] + dir(0)[0][0])}",
+                "${type('').mro()}",
+                "${vars()}",
+                "${format('', '')}",
+                "${breakpoint()}",
+            ]
+            for p in payloads:
+                with self.subTest(payload=p):
+                    self.assertEqual(expression.ConstantTemplate(p).resolve_data({}), p)
+        finally:
+            sandbox.SANDBOX = sandbox_copy

--- a/runtime/bamboo-pipeline/pipeline/utils/mako_utils/checker.py
+++ b/runtime/bamboo-pipeline/pipeline/utils/mako_utils/checker.py
@@ -19,8 +19,19 @@ from mako import parsetree
 from mako.exceptions import MakoException
 from mako.lexer import Lexer
 
+from pipeline.core.data import mako_safety
+
 from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
+
+
+def validate_node_filter_callables(node: parsetree.Node):
+    # Mako stores inline `${expr | ...}` filter callables in `escapes_code`;
+    # tag-level filters use `filter_args`. Both are executed by create_filter_callable().
+    if hasattr(node, "escapes_code"):
+        mako_safety.validate_filter_args(node.escapes_code.args)
+    if hasattr(node, "filter_args"):
+        mako_safety.validate_filter_args(node.filter_args.args)
 
 
 def parse_template_nodes(
@@ -33,14 +44,15 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        code = code_extractor.extract(node)
-        if code is None:
-            continue
+        validate_node_filter_callables(node)
 
-        ast_node = ast.parse(code, "<unknown>", "exec")
-        node_visitor.visit(ast_node)
+        code = code_extractor.extract(node)
+        if code is not None:
+            ast_node = ast.parse(code, "<unknown>", "exec")
+            node_visitor.visit(ast_node)
+
         if hasattr(node, "nodes"):
-            parse_template_nodes(node.nodes, node_visitor)
+            parse_template_nodes(node.nodes, node_visitor, code_extractor)
 
 
 def check_mako_template_safety(text: str, node_visitor: ast.NodeVisitor, code_extractor: MakoNodeCodeExtractor) -> bool:

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -391,3 +391,14 @@ def test_mako_nested_dunder_expression_is_blocked():
     payload = "${().__class__.mro()}"
 
     assert Template(payload).render({}) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${"{0.__class__}".format("")}',
+        '${"{value.__class__}".format_map({"value": ""})}',
+    ],
+)
+def test_mako_format_private_lookup_is_blocked(payload):
+    _assert_forbidden_template(payload)

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -402,3 +402,51 @@ def test_mako_nested_dunder_expression_is_blocked():
 )
 def test_mako_format_private_lookup_is_blocked(payload):
     _assert_forbidden_template(payload)
+
+
+# ---------------------------------------------------------------------------
+# 纵深防御回归：以下 payload 当前**能通过 AST 安全检查**（visitor 只能识别字面 dunder /
+# 已知禁用属性，无法穿透 BinOp/format/getattr 组合出的动态字符串），但通过运行期 sandbox
+# shield (`MAKO_SANDBOX_SHIELD_WORDS`) 阻断。
+#
+# 把这些 payload 纳入回归是为了：未来一旦 ``Settings.MAKO_SANDBOX_SHIELD_WORDS`` 被
+# 误改成不完整列表，或者 ``_render_template`` 把 ``context.update`` 顺序换成允许 context
+# 覆盖 shield，这些用例会立刻红，提示重新评估纵深防御。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # BinOp 字符串拼接绕过字面量 dunder 检测
+        "${getattr('', '__cl' + 'ass__')}",
+        # 完整 subclasses RCE 链（多重 getattr + 字符串拼接）
+        (
+            "${getattr(getattr(getattr('', '__cl' + 'ass__'), '__ba' + 'se__'),"
+            " '__sub' + 'classes__')()}"
+        ),
+        # 通过 dir(0)[0][0] 间接得到下划线字符再拼出 __class__
+        "${getattr('', dir(0)[0][0] + dir(0)[0][0] + 'class' + dir(0)[0][0] + dir(0)[0][0])}",
+        # type / object / vars 等 callable 走 Name 调用
+        "${type('').mro()}",
+        "${vars()}",
+        # 内建 format() 走 Name 调用（visitor 仅拦 Attribute 形式的 .format(...)）
+        "${format('', '')}",
+        # breakpoint 未屏蔽时会触发 pdb，构成 DoS / 调试 RCE；shield 完整时必须 inert
+        "${breakpoint()}",
+    ],
+)
+def test_mako_latent_bypass_is_inert_at_render(payload):
+    """这些 payload 必须始终在 ``Template.render`` 后保持 inert（原样回显）。
+
+    它们能通过 AST 安全检查（visitor 只能识别字面 dunder / 已知禁用属性，无法穿透
+    BinOp / dir()[0][0] / Name 调用组合出的动态字符串与危险内建调用），所以**唯一的
+    防御**是 ``Settings.MAKO_SANDBOX_SHIELD_WORDS`` 中包含 ``getattr/type/vars/format/
+    breakpoint`` 等条目。若任何一条变成"非原样输出"，意味着 shield 被弱化或
+    ``_render_template`` 的 context 合并顺序被改动，需要立刻重新评估安全边界。
+    """
+    rendered = Template(payload).render({})
+    assert rendered == payload, (
+        "Mako sandbox bypass regression: payload {!r} rendered to {!r}, expected inert echo. "
+        "Check Settings.MAKO_SANDBOX_SHIELD_WORDS completeness."
+    ).format(payload, rendered)

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -13,8 +13,14 @@ specific language governing permissions and limitations under the License.
 
 import datetime
 
+import pytest
+from mako.template import Template as MakoTemplate
+
 from bamboo_engine.config import Settings
 from bamboo_engine.template import Template
+from bamboo_engine.utils import mako_safety
+from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
+from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
 def test_get_reference():
@@ -144,9 +150,6 @@ def test_mako_attack():
 # ---------------------------------------------------------------------------
 
 
-import pytest  # noqa: E402
-
-
 @pytest.fixture
 def whitelist_mode():
     """在 ``Settings`` 上切换 ``MAKO_TEMPLATE_NAME_WHITELIST_MODE``，测试结束后还原。"""
@@ -178,6 +181,39 @@ def test_mako_whitelist_default_blocks_self_module_namespace():
     assert Template(payload).render({}) == payload
 
 
+def _assert_forbidden_template(payload):
+    with pytest.raises(ForbiddenMakoTemplateException):
+        check_mako_template_safety(
+            payload,
+            mako_safety.SingleLineNodeVisitor(),
+            mako_safety.SingleLinCodeExtractor(),
+        )
+
+
+def test_mako_filter_side_effect_expression_is_blocked():
+    payload = "${'x'|((side_effect() or str))}"
+
+    _assert_forbidden_template(payload)
+
+
+def test_mako_filter_dunder_chain_is_blocked():
+    payload = "${'x'|().__class__.__bases__[0].__subclasses__}"
+
+    _assert_forbidden_template(payload)
+
+
+def test_mako_filter_list_blocks_any_malicious_item():
+    payload = "${'x'|h, (side_effect() or str)}"
+
+    _assert_forbidden_template(payload)
+
+
+def test_mako_decode_filter_private_attribute_is_blocked():
+    payload = "${'x'|decode.__class__}"
+
+    _assert_forbidden_template(payload)
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -192,6 +228,19 @@ def test_mako_whitelist_default_blocks_self_module_namespace():
 def test_mako_whitelist_blocks_reserved_namespaces(whitelist_mode, payload):
     whitelist_mode("enforce")
     assert Template(payload).render({}) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '<%page expression_filter="(side_effect() or str)"/>${name}',
+        '<%def name="render_name(name)" filter="(side_effect() or str)">${name}</%def>${render_name("x")}',
+        '<%block filter="(side_effect() or str)">x</%block>',
+        '<%text filter="(side_effect() or str)">x</%text>',
+    ],
+)
+def test_mako_tag_filter_callables_are_blocked(payload):
+    _assert_forbidden_template(payload)
 
 
 @pytest.mark.parametrize(
@@ -300,3 +349,45 @@ def test_mako_whitelist_warn_mode_does_not_block_but_logs(whitelist_mode, caplog
         except Exception:
             pass
     assert any("name not in whitelist" in r.getMessage() or "self" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${' x ' | h}",
+        "${' x ' | trim}",
+        "${' x ' | h, trim}",
+        "${'x' | n}",
+        "${b'abc' | decode.utf8}",
+    ],
+)
+def test_mako_builtin_filters_remain_allowed(payload):
+    check_mako_template_safety(
+        payload,
+        mako_safety.SingleLineNodeVisitor(),
+        mako_safety.SingleLinCodeExtractor(),
+    )
+
+
+def test_mako_builtin_filter_rendering_still_works():
+    assert MakoTemplate("${'x' | h}").render_unicode() == "x"
+    assert MakoTemplate("${' x ' | trim}").render_unicode() == "x"
+
+
+def test_mako_filter_side_effect_is_not_executed_by_template_render():
+    sentinel = {"called": False}
+
+    def side_effect():
+        sentinel["called"] = True
+        return str
+
+    payload = "${'x'|((side_effect() or str))}"
+
+    assert Template(payload).render({"side_effect": side_effect}) == payload
+    assert sentinel["called"] is False
+
+
+def test_mako_nested_dunder_expression_is_blocked():
+    payload = "${().__class__.mro()}"
+
+    assert Template(payload).render({}) == payload


### PR DESCRIPTION
## 背景

`master`（3.29.8）此前已合入**根标识符白名单**（`MAKO_TEMPLATE_NAME_WHITELIST_MODE` + 危险 attr 拦截）这组修复。但 Mako **filter 加固**那组修复当初是从 `4.0.1` 切出来的，没有基于含白名单的最新 master，两条线并行发散、改动同一批文件，直接合并存在冲突。

本 PR 将 filter 加固重新基于最新 `master` 集成，逐文件解决冲突，使**白名单**与 **filter 加固**两套防护并存生效。

## 修复内容

Mako 模板的 `${expr | filter}` filter 表达式此前**未经过 AST 安全检查**，可绕过 `SingleLineNodeVisitor` / 白名单，构造出 RCE（通过子类遍历 `().__class__.__base__.__subclasses__()...` 拿到 `os.system`）。本次加固：

- **filter 表达式校验**：`checker.parse_template_nodes` 新增 `validate_node_filters`，对 `${... | filter}` 与 tag-level（`<%page/def/block/text filter=...>`）的 filter 参数调用 `validate_filter_args` 做白名单校验（仅放行 `n/h/x/u/trim/...` 与受限的 `decode.*`）。
- **`SingleLineNodeVisitor` 收紧**：拦截 `format` / `format_map` 查找绕过、`__`-前缀的 subscript key（`a['__class__']`）、dunder Call。
- **sandbox shield 默认安全**：`MAKO_SANDBOX_SHIELD_WORDS` 默认补充 `breakpoint` / `format`；bamboo-pipeline runtime 侧未显式配置时也兜底到加固后的默认列表。
- **bamboo-pipeline runtime 平行加固**：`pipeline.core.data.mako_safety` / `pipeline.utils.mako_utils.checker` 同步实现（两条渲染路径独立，需各自防护）。

## 改动文件

```
 bamboo_engine/config.py                                |   2 +
 bamboo_engine/utils/mako_safety.py                     |  44 +
 bamboo_engine/utils/mako_utils/checker.py              |  22 +-
 runtime/.../pipeline/conf/default_settings.py          |  48 +-
 runtime/.../pipeline/core/data/mako_safety.py          |  53 +
 runtime/.../pipeline/utils/mako_utils/checker.py       |  22 +-
 runtime/.../pipeline/tests/core/data/test_expression.py| 126 +-
 tests/template/test_template.py                        | 156 +-
```

## 验证

- 引擎单测 `tests/template/test_template.py`：**55 passed**（白名单 + filter + RCE gadget + 正常渲染）
- bamboo-pipeline runtime 侧 `mako_safety`/`checker`：11 个恶意 payload 全部 blocked、5 个合法 filter 全部 allowed、白名单 visitor 拦截 SSTI/未知根名并放行正常表达式
- 端到端（真实 `Template().render()`，套用 enforce + shield 配置）：
  - filter-callable 子类遍历 gadget → blocked（`unsupported filter expression`）
  - `"".__class__.__mro__` dunder 链 → blocked（`can not access private attribute`）
  - `self.module.*` SSTI → blocked（whitelist: dangerous attribute）
  - `os.path.os.system(...)` 反向引用 → blocked（whitelist: dangerous attribute）
  - 未生成任何 marker 文件；`name.upper()` / `|trim` / `os.path.join` 等正常渲染 OK

## Test plan

- [x] 引擎单测全绿
- [x] pipeline runtime 侧 mako 安全校验全绿
- [x] 端到端 RCE / SSTI 全部 inert，正常模板不受损
- [ ] CI 通过

Made with [Cursor](https://cursor.com)