### PR TITLE
fix(mako): harden RCE sandbox checks for 3.24 LTS

### DIFF
--- a/bamboo_engine/config.py
+++ b/bamboo_engine/config.py
@@ -21,6 +21,7 @@ class Settings:
 
     MAKO_SANDBOX_SHIELD_WORDS = [
         "ascii",
+        "breakpoint",
         "bytearray",
         "bytes",
         "callable",
@@ -33,6 +34,7 @@ class Settings:
         "exec",
         "eval",
         "filter",
+        "format",
         "frozenset",
         "getattr",
         "globals",
@@ -62,5 +64,17 @@ class Settings:
     ]
 
     MAKO_SANDBOX_IMPORT_MODULES = {}
+
+    # 模板根标识符白名单模式：
+    #   "off"     - 关闭白名单（兼容历史行为）
+    #   "warn"    - 仅记录违规日志，不阻断渲染（灰度阶段使用）
+    #   "enforce" - 违规即按当前 deny-list 风格拦截（行为同 ForbiddenMakoTemplateException）
+    # 默认 "enforce"，避免默认安装后继续暴露 Mako 渲染期保留命名空间注入链路。
+    # 如接入方确有兼容性风险，可在自身 settings 中临时切到 "warn" 或 "off"。
+    MAKO_TEMPLATE_NAME_WHITELIST_MODE = "enforce"
+
+    # 在白名单基础上额外允许的根标识符（除 context/导入模块/SAFE_BUILTIN_NAMES 之外）。
+    # 接入方通常用于声明 ``_system``、``_loop`` 这类 Mako 渲染期才注入的特殊对象名。
+    MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset()
 
     RERUN_INDEX_OFFSET = 0

--- a/bamboo_engine/template/template.py
+++ b/bamboo_engine/template/template.py
@@ -23,6 +23,7 @@ from mako.template import Template as MakoTemplate
 from mako import lexer, codegen
 from mako.exceptions import MakoException
 
+from bamboo_engine.config import Settings
 from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
 from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 from bamboo_engine.utils import mako_safety
@@ -159,6 +160,24 @@ class Template:
             except Exception:
                 logger.exception("{} safety check error.".format(tpl))
                 continue
+            # 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``）。off 模式下保持
+            # 历史行为；warn 模式只打日志；enforce 模式命中即按 SingleLineNodeVisitor
+            # 风格 inert 掉这一段模板（``logger.warning + continue``）。
+            whitelist_mode = getattr(Settings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", "off")
+            if whitelist_mode in ("warn", "enforce"):
+                allowed_names = mako_safety.build_allowed_names(context)
+                try:
+                    check_mako_template_safety(
+                        tpl,
+                        mako_safety.WhitelistNameVisitor(allowed_names, mode=whitelist_mode),
+                        mako_safety.SingleLinCodeExtractor(),
+                    )
+                except ForbiddenMakoTemplateException as e:
+                    logger.warning("forbidden by whitelist: {}, exception: {}".format(tpl, e))
+                    continue
+                except Exception:
+                    logger.exception("{} whitelist check error.".format(tpl))
+                    continue
             resolved = Template._render_template(tpl, context)
             string = string.replace(tpl, resolved)
         return string

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -14,7 +14,9 @@ specific language governing permissions and limitations under the License.
 # Mako 安全工具
 
 
-from ast import NodeVisitor
+import ast
+import logging
+import re
 
 from mako import parsetree
 
@@ -22,7 +24,127 @@ from .mako_utils.code_extract import MakoNodeCodeExtractor
 from .mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
-class SingleLineNodeVisitor(NodeVisitor):
+logger = logging.getLogger("root")
+
+# 与 ``MAKO_SANDBOX_SHIELD_WORDS`` 不重叠的"安全内建函数"集合。
+# 用于白名单模式下默认放行的根标识符。
+# 不包含 ``bytes/bytearray/frozenset/memoryview/object/type/vars/getattr/...``
+# 等常出现在 shield 列表中的内建——它们即便能通过 AST 也会在渲染期被屏蔽成 ``None``，
+# 留在白名单里只会带来认知噪音。
+SAFE_BUILTIN_NAMES = frozenset(
+    {
+        "True",
+        "False",
+        "None",
+        # 类型构造（不会构造危险对象）
+        "bool",
+        "int",
+        "float",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        # 数学 / 长度
+        "abs",
+        "round",
+        "pow",
+        "sum",
+        "min",
+        "max",
+        "len",
+        # 序列
+        "range",
+        "slice",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        # 逻辑
+        "all",
+        "any",
+    }
+)
+
+# Mako 在渲染期会向模板命名空间注入的保留对象名，用户模板里出现这些名字时
+# 极大概率是在尝试触达模板内部对象（``self.module.cache.util.os...`` SSTI 链路）。
+# 对它们直接拒绝，可以堵住绝大多数 namespace 链式 RCE 路径。
+MAKO_RESERVED_NAMESPACES = frozenset(
+    {
+        "self",
+        "context",
+        "local",
+        "parent",
+        "next",
+        "caller",
+        "pageargs",
+        "UNDEFINED",
+        "STOP_RENDERING",
+    }
+)
+
+# attr 链路上一旦出现下列名字就立刻拒绝。
+#
+# 根 ``Name`` 白名单只能防"未授权根标识符"，挡不住通过白名单根名（如 ``os``、``datetime``、
+# ``re``）反向触达危险模块的链路：
+#
+# * ``${os.path.os.popen(...)}``        — ``os.path`` 内部 ``import os``
+# * ``${datetime.sys.modules['os']...}`` — ``datetime`` 内部 ``import sys``
+# * ``${re.enum.sys.modules['os']...}``  — ``re`` 重新 export ``enum``，``enum`` 内 ``import sys``
+#
+# 所有这些链路都需要 attr 链上出现 ``os / sys / subprocess / shutil / ctypes / socket /
+# builtins / modules`` 之一，或调用 ``popen / system / exec* / spawn* / fork*`` 之一。
+# 直接把 attr 名拉黑，就能切掉公共必经路径。这是纵深防御里的"任何路径都不该带这些字"，
+# 不是替代根名白名单。
+DANGEROUS_ATTR_NAMES = frozenset(
+    {
+        # 直接拿到危险模块对象
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "ctypes",
+        "socket",
+        "_thread",
+        "threading",
+        "builtins",
+        "__builtins__",
+        # 通过模块字典反向触达任意已导入模块
+        "modules",
+        # 进程 / 文件描述符相关原语（即便有人未来误把 ``os`` 加进白名单，也再加一层）
+        "popen",
+        "popen2",
+        "popen3",
+        "popen4",
+        "system",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "kill",
+    }
+)
+
+FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
+SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class SingleLineNodeVisitor(ast.NodeVisitor):
     """
     遍历语法树节点，遇到魔术方法使用或 import 时，抛出异常
     """
@@ -30,19 +152,63 @@ class SingleLineNodeVisitor(NodeVisitor):
     def __init__(self, *args, **kwargs):
         super(SingleLineNodeVisitor, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def _get_subscript_key(node):
+        slice_node = node.slice
+        constant_node = getattr(ast, "Constant", None)
+        if (
+            constant_node is not None
+            and isinstance(slice_node, constant_node)
+            and isinstance(slice_node.value, str)
+        ):
+            return slice_node.value
+        if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):
+            return slice_node.s
+        return None
+
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Name(self, node):
         if node.id.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private method")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        subscript_key = self._get_subscript_key(node)
+        if isinstance(subscript_key, str) and subscript_key.startswith("__"):
+            raise ForbiddenMakoTemplateException("can not access private key")
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         raise ForbiddenMakoTemplateException("can not use import statement")
 
     def visit_ImportFrom(self, node):
         self.visit_Import(node)
+
+
+def validate_filter_args(filter_args):
+    for filter_arg in filter_args:
+        normalized_filter = filter_arg.strip()
+        if normalized_filter in SAFE_FILTERS:
+            continue
+        decode_filter_parts = normalized_filter.split(".")
+        if (
+            SAFE_DECODE_FILTER_PATTERN.match(normalized_filter)
+            and "__" not in normalized_filter
+            and not any(part.startswith("_") for part in decode_filter_parts[1:])
+        ):
+            continue
+        raise ForbiddenMakoTemplateException("unsupported filter expression: [{}]".format(normalized_filter))
 
 
 class SingleLinCodeExtractor(MakoNodeCodeExtractor):
@@ -53,3 +219,161 @@ class SingleLinCodeExtractor(MakoNodeCodeExtractor):
             return None
         else:
             raise ForbiddenMakoTemplateException("Unsupported node: [{}]".format(node.__class__.__name__))
+
+
+def _deformat_var_key(key):
+    """``${name}`` -> ``name``；其它 key 原样返回。"""
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def build_allowed_names(context, *, extra=()):
+    """根据当前渲染 context 与全局 ``Settings`` 计算白名单的根标识符集合。
+
+    包含：
+      * ``context`` 中的键（``${name}`` 形式自动 deformat）
+      * ``Settings.MAKO_SANDBOX_IMPORT_MODULES`` 中每个 alias 的首段
+        （例：``os.path`` → ``os``）
+      * :data:`SAFE_BUILTIN_NAMES`
+      * ``Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST``
+      * 调用方传入的 ``extra``
+    """
+    # 局部 import 避免循环依赖（``Settings`` 在 ``bamboo_engine.config``）。
+    from bamboo_engine.config import Settings
+
+    allowed = set(SAFE_BUILTIN_NAMES)
+
+    for key in context.keys() if context else ():
+        allowed.add(_deformat_var_key(key))
+
+    import_modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    for alias in import_modules.values():
+        if alias:
+            allowed.add(alias.split(".", 1)[0])
+
+    extra_whitelist = getattr(Settings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", None) or ()
+    allowed.update(extra_whitelist)
+    allowed.update(extra)
+
+    return allowed
+
+
+class WhitelistNameVisitor(ast.NodeVisitor):
+    """根标识符白名单 visitor。
+
+    只允许 Load 语义的 ``Name`` 节点引用 ``allowed_names`` 中的标识符；其余一律按
+    ``mode`` 处理：
+
+      * ``warn``：调用 ``on_violation`` / 打 warning 日志，**不抛异常**（灰度模式）。
+      * ``enforce``：抛 :exc:`ForbiddenMakoTemplateException`，由
+        :func:`bamboo_engine.utils.mako_utils.checker.check_mako_template_safety` 捕获。
+
+    本 visitor 还显式拦截 :data:`MAKO_RESERVED_NAMESPACES` 中的标识符，
+    无论是否被传入 ``allowed_names`` 都会被拒，避免误把 ``self/context/...`` 加进
+    上下文导致 SSTI 链路被放行。
+
+    支持 ``ListComp / SetComp / DictComp / GeneratorExp / Lambda`` 引入的局部
+    绑定——这些临时变量会被压入作用域栈，在子树访问完后自动弹出。
+    """
+
+    def __init__(self, allowed_names, mode="enforce", on_violation=None):
+        if mode not in {"warn", "enforce"}:
+            raise ValueError("invalid whitelist mode: {}".format(mode))
+        self.allowed_names = set(allowed_names)
+        self.mode = mode
+        self.on_violation = on_violation
+        self.scope_stack = []
+
+    def _name_allowed(self, name):
+        if name in MAKO_RESERVED_NAMESPACES:
+            return False
+        if name in self.allowed_names:
+            return True
+        for scope in self.scope_stack:
+            if name in scope:
+                return True
+        return False
+
+    def _violate(self, name, reason):
+        msg = "name not in whitelist: {} ({})".format(name, reason)
+        if self.on_violation is not None:
+            try:
+                self.on_violation(name, reason)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("on_violation callback raised")
+        if self.mode == "enforce":
+            raise ForbiddenMakoTemplateException(msg)
+        logger.warning("[mako_whitelist] %s", msg)
+
+    @staticmethod
+    def _collect_targets(target, into):
+        if isinstance(target, ast.Name):
+            into.add(target.id)
+        elif isinstance(target, ast.Starred):
+            WhitelistNameVisitor._collect_targets(target.value, into)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                WhitelistNameVisitor._collect_targets(elt, into)
+
+    def visit_Name(self, node):
+        # Store / Del 上下文是赋值/删除目标，由 _enter_* 显式处理，跳过命名检查
+        if not isinstance(node.ctx, ast.Load):
+            return
+        if node.id in MAKO_RESERVED_NAMESPACES:
+            self._violate(node.id, "mako reserved namespace")
+            return
+        if not self._name_allowed(node.id):
+            self._violate(node.id, "not in whitelist")
+
+    def visit_Attribute(self, node):
+        # 单下划线 attr 拒绝：堵 ``context._with_template / context._kwargs`` 这类
+        # Python "半私有" 通道（双下划线已经在 ``SingleLineNodeVisitor`` 拦过，这里
+        # 顺手收紧成单下划线，覆盖更广）。
+        if node.attr.startswith("_"):
+            self._violate(node.attr, "private attribute")
+            return
+        # 危险 attr 名拒绝：堵 ``${os.path.os.popen(...)}`` /
+        # ``${datetime.sys.modules['os'].popen(...)}`` 类反向引用链路。
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            self._violate(node.attr, "dangerous attribute")
+            return
+        self.generic_visit(node)
+
+    def _enter_comprehension(self, node):
+        local = set()
+        for gen in node.generators:
+            self._collect_targets(gen.target, local)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()
+
+    def visit_ListComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_SetComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_DictComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_GeneratorExp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_Lambda(self, node):
+        local = set()
+        args = node.args
+        local.update(arg.arg for arg in args.args)
+        local.update(arg.arg for arg in args.kwonlyargs)
+        local.update(arg.arg for arg in getattr(args, "posonlyargs", ()) or ())
+        if args.vararg:
+            local.add(args.vararg.arg)
+        if args.kwarg:
+            local.add(args.kwarg.arg)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()

--- a/bamboo_engine/utils/mako_utils/checker.py
+++ b/bamboo_engine/utils/mako_utils/checker.py
@@ -19,8 +19,19 @@ from mako import parsetree
 from mako.exceptions import MakoException
 from mako.lexer import Lexer
 
+from bamboo_engine.utils import mako_safety
+
 from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
+
+
+def validate_node_filter_callables(node: parsetree.Node):
+    # Mako stores inline `${expr | ...}` filter callables in `escapes_code`;
+    # tag-level filters use `filter_args`. Both are executed by create_filter_callable().
+    if hasattr(node, "escapes_code"):
+        mako_safety.validate_filter_args(node.escapes_code.args)
+    if hasattr(node, "filter_args"):
+        mako_safety.validate_filter_args(node.filter_args.args)
 
 
 def parse_template_nodes(
@@ -35,14 +46,15 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        code = code_extractor.extract(node)
-        if code is None:
-            continue
+        validate_node_filter_callables(node)
 
-        ast_node = ast.parse(code, "<unknown>", "exec")
-        node_visitor.visit(ast_node)
+        code = code_extractor.extract(node)
+        if code is not None:
+            ast_node = ast.parse(code, "<unknown>", "exec")
+            node_visitor.visit(ast_node)
+
         if hasattr(node, "nodes"):
-            parse_template_nodes(node.nodes, node_visitor)
+            parse_template_nodes(node.nodes, node_visitor, code_extractor)
 
 
 def check_mako_template_safety(text: str, node_visitor: ast.NodeVisitor, code_extractor: MakoNodeCodeExtractor) -> bool:

--- a/runtime/bamboo-pipeline/pipeline/conf/default_settings.py
+++ b/runtime/bamboo-pipeline/pipeline/conf/default_settings.py
@@ -88,7 +88,53 @@ EXPIRED_TASK_CLEAN_NUM_LIMIT = getattr(settings, "EXPIRED_TASK_CLEAN_NUM_LIMIT",
 TASK_EXPIRED_MONTH = getattr(settings, "TASK_EXPIRED_MONTH", 6)
 
 # MAKO sandbox config
-MAKO_SANDBOX_SHIELD_WORDS = getattr(settings, "MAKO_SANDBOX_SHIELD_WORDS", [])
+# 默认屏蔽所有可被用于 SSTI 链路的内建可调用名字（getattr/eval/exec/open/type/__import__ 等）。
+# 这是一份与 ``bamboo_engine.config.Settings.MAKO_SANDBOX_SHIELD_WORDS`` 保持同步的安全兜底，
+# 任何未显式设置 ``MAKO_SANDBOX_SHIELD_WORDS`` 的 Django 宿主也能开箱即得到屏蔽。
+DEFAULT_MAKO_SANDBOX_SHIELD_WORDS = [
+    "ascii",
+    "breakpoint",
+    "bytearray",
+    "bytes",
+    "callable",
+    "chr",
+    "classmethod",
+    "compile",
+    "delattr",
+    "dir",
+    "divmod",
+    "exec",
+    "eval",
+    "filter",
+    "format",
+    "frozenset",
+    "getattr",
+    "globals",
+    "hasattr",
+    "hash",
+    "help",
+    "id",
+    "input",
+    "isinstance",
+    "issubclass",
+    "iter",
+    "locals",
+    "map",
+    "memoryview",
+    "next",
+    "object",
+    "open",
+    "print",
+    "property",
+    "repr",
+    "setattr",
+    "staticmethod",
+    "super",
+    "type",
+    "vars",
+    "__import__",
+]
+MAKO_SANDBOX_SHIELD_WORDS = getattr(settings, "MAKO_SANDBOX_SHIELD_WORDS", DEFAULT_MAKO_SANDBOX_SHIELD_WORDS)
 MAKO_SANDBOX_IMPORT_MODULES = getattr(settings, "MAKO_SANDBOX_IMPORT_MODULES", {})
 MAKO_SAFETY_CHECK = getattr(settings, "MAKO_SAFETY_CHECK", True)
 

--- a/runtime/bamboo-pipeline/pipeline/core/data/expression.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/expression.py
@@ -141,6 +141,26 @@ class ConstantTemplate(object):
                 except Exception:
                     logger.exception("{} safety check error.".format(tpl))
                     continue
+                # 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``），延用引擎全局
+                # ``Settings`` 配置；off 时保持历史行为，warn 仅打日志，enforce 命中即
+                # 按 SingleLineNodeVisitor 风格 inert 掉这一段模板。
+                from bamboo_engine.config import Settings as _BambooSettings
+
+                whitelist_mode = getattr(_BambooSettings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", "off")
+                if whitelist_mode in ("warn", "enforce"):
+                    allowed_names = mako_safety.build_allowed_names(value_maps)
+                    try:
+                        check_mako_template_safety(
+                            tpl,
+                            mako_safety.WhitelistNameVisitor(allowed_names, mode=whitelist_mode),
+                            mako_safety.SingleLinCodeExtractor(),
+                        )
+                    except ForbiddenMakoTemplateException as e:
+                        logger.warning("forbidden by whitelist: {}, exception: {}".format(tpl, e))
+                        continue
+                    except Exception:
+                        logger.exception("{} whitelist check error.".format(tpl))
+                        continue
             resolved = ConstantTemplate.resolve_template(tpl, value_maps)
             string = string.replace(tpl, resolved)
         return string

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -10,8 +10,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-from ast import NodeVisitor
+import ast
+import logging
+import re
 
 from mako import parsetree
 
@@ -19,7 +20,103 @@ from pipeline.utils.mako_utils.code_extract import MakoNodeCodeExtractor
 from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
-class SingleLineNodeVisitor(NodeVisitor):
+logger = logging.getLogger("root")
+
+# 与 ``MAKO_SANDBOX_SHIELD_WORDS`` 不重叠的"安全内建函数"集合，详见
+# ``bamboo_engine.utils.mako_safety.SAFE_BUILTIN_NAMES``。
+SAFE_BUILTIN_NAMES = frozenset(
+    {
+        "True",
+        "False",
+        "None",
+        "bool",
+        "int",
+        "float",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        "abs",
+        "round",
+        "pow",
+        "sum",
+        "min",
+        "max",
+        "len",
+        "range",
+        "slice",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        "all",
+        "any",
+    }
+)
+
+# Mako 渲染期保留命名空间，详见 ``bamboo_engine.utils.mako_safety.MAKO_RESERVED_NAMESPACES``。
+MAKO_RESERVED_NAMESPACES = frozenset(
+    {
+        "self",
+        "context",
+        "local",
+        "parent",
+        "next",
+        "caller",
+        "pageargs",
+        "UNDEFINED",
+        "STOP_RENDERING",
+    }
+)
+
+# attr 链路危险字段，详见 ``bamboo_engine.utils.mako_safety.DANGEROUS_ATTR_NAMES``。
+DANGEROUS_ATTR_NAMES = frozenset(
+    {
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "ctypes",
+        "socket",
+        "_thread",
+        "threading",
+        "builtins",
+        "__builtins__",
+        "modules",
+        "popen",
+        "popen2",
+        "popen3",
+        "popen4",
+        "system",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "kill",
+    }
+)
+
+FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
+SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class SingleLineNodeVisitor(ast.NodeVisitor):
     """
     遍历语法树节点，遇到魔术方法使用或 import 时，抛出异常
     """
@@ -27,19 +124,72 @@ class SingleLineNodeVisitor(NodeVisitor):
     def __init__(self, *args, **kwargs):
         super(SingleLineNodeVisitor, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def _get_subscript_key(node):
+        slice_node = node.slice
+        constant_node = getattr(ast, "Constant", None)
+        if (
+            constant_node is not None
+            and isinstance(slice_node, constant_node)
+            and isinstance(slice_node.value, str)
+        ):
+            return slice_node.value
+        if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):
+            return slice_node.s
+        return None
+
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Name(self, node):
         if node.id.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private method")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        subscript_key = self._get_subscript_key(node)
+        if isinstance(subscript_key, str) and subscript_key.startswith("__"):
+            raise ForbiddenMakoTemplateException("can not access private key")
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         raise ForbiddenMakoTemplateException("can not use import statement")
 
     def visit_ImportFrom(self, node):
         self.visit_Import(node)
+
+
+def validate_filter_args(filter_args):
+    """对 ``${expr | filter}`` 与 tag-level ``filter=`` 的 filter callable 做白名单校验。
+
+    Mako 在渲染期会把 filter 表达式作为 Python 代码 ``eval`` 出 callable，因此必须在
+    parse 阶段就拒绝任意 Python 表达式，否则攻击者可以通过 ``(side_effect() or str)``
+    这种 filter 表达式绕过主表达式上的 AST 检查。
+    """
+
+    for filter_arg in filter_args:
+        normalized_filter = filter_arg.strip()
+        if not normalized_filter:
+            continue
+        if normalized_filter in SAFE_FILTERS:
+            continue
+        decode_filter_parts = normalized_filter.split(".")
+        if (
+            SAFE_DECODE_FILTER_PATTERN.match(normalized_filter)
+            and "__" not in normalized_filter
+            and not any(part.startswith("_") for part in decode_filter_parts[1:])
+        ):
+            continue
+        raise ForbiddenMakoTemplateException("unsupported filter expression: [{}]".format(normalized_filter))
 
 
 class SingleLinCodeExtractor(MakoNodeCodeExtractor):
@@ -50,3 +200,139 @@ class SingleLinCodeExtractor(MakoNodeCodeExtractor):
             return None
         else:
             raise ForbiddenMakoTemplateException("Unsupported node: [{}]".format(node.__class__.__name__))
+
+
+def _deformat_var_key(key):
+    """``${name}`` -> ``name``；其它 key 原样返回。"""
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def build_allowed_names(context, *, extra=()):
+    """legacy 模板渲染白名单根标识符集合。
+
+    与 ``bamboo_engine.utils.mako_safety.build_allowed_names`` 行为一致：
+    复用 ``bamboo_engine.config.Settings`` 上的 ``MAKO_SANDBOX_IMPORT_MODULES /
+    MAKO_TEMPLATE_NAME_EXTRA_WHITELIST`` 配置，避免接入方维护两套白名单源。
+    """
+    from bamboo_engine.config import Settings
+
+    allowed = set(SAFE_BUILTIN_NAMES)
+
+    for key in context.keys() if context else ():
+        allowed.add(_deformat_var_key(key))
+
+    import_modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    for alias in import_modules.values():
+        if alias:
+            allowed.add(alias.split(".", 1)[0])
+
+    extra_whitelist = getattr(Settings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", None) or ()
+    allowed.update(extra_whitelist)
+    allowed.update(extra)
+
+    return allowed
+
+
+class WhitelistNameVisitor(ast.NodeVisitor):
+    """legacy 渲染路径用的白名单 visitor，行为对齐
+    ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor``。
+    """
+
+    def __init__(self, allowed_names, mode="enforce", on_violation=None):
+        if mode not in {"warn", "enforce"}:
+            raise ValueError("invalid whitelist mode: {}".format(mode))
+        self.allowed_names = set(allowed_names)
+        self.mode = mode
+        self.on_violation = on_violation
+        self.scope_stack = []
+
+    def _name_allowed(self, name):
+        if name in MAKO_RESERVED_NAMESPACES:
+            return False
+        if name in self.allowed_names:
+            return True
+        for scope in self.scope_stack:
+            if name in scope:
+                return True
+        return False
+
+    def _violate(self, name, reason):
+        msg = "name not in whitelist: {} ({})".format(name, reason)
+        if self.on_violation is not None:
+            try:
+                self.on_violation(name, reason)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("on_violation callback raised")
+        if self.mode == "enforce":
+            raise ForbiddenMakoTemplateException(msg)
+        logger.warning("[mako_whitelist] %s", msg)
+
+    @staticmethod
+    def _collect_targets(target, into):
+        if isinstance(target, ast.Name):
+            into.add(target.id)
+        elif isinstance(target, ast.Starred):
+            WhitelistNameVisitor._collect_targets(target.value, into)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                WhitelistNameVisitor._collect_targets(elt, into)
+
+    def visit_Name(self, node):
+        if not isinstance(node.ctx, ast.Load):
+            return
+        if node.id in MAKO_RESERVED_NAMESPACES:
+            self._violate(node.id, "mako reserved namespace")
+            return
+        if not self._name_allowed(node.id):
+            self._violate(node.id, "not in whitelist")
+
+    def visit_Attribute(self, node):
+        # 与新引擎 ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor.visit_Attribute``
+        # 保持一致：单下划线前缀 + 危险 attr 名一律拒绝，堵反向引用 SSTI 链路。
+        if node.attr.startswith("_"):
+            self._violate(node.attr, "private attribute")
+            return
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            self._violate(node.attr, "dangerous attribute")
+            return
+        self.generic_visit(node)
+
+    def _enter_comprehension(self, node):
+        local = set()
+        for gen in node.generators:
+            self._collect_targets(gen.target, local)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()
+
+    def visit_ListComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_SetComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_DictComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_GeneratorExp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_Lambda(self, node):
+        local = set()
+        args = node.args
+        local.update(arg.arg for arg in args.args)
+        local.update(arg.arg for arg in args.kwonlyargs)
+        local.update(arg.arg for arg in getattr(args, "posonlyargs", ()) or ())
+        if args.vararg:
+            local.add(args.vararg.arg)
+        if args.kwarg:
+            local.add(args.kwarg.arg)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -59,10 +59,12 @@ class TestConstantTemplate(TestCase):
 
     def test_resolve_template_with_curly_braces(self):
         cons_tmpl = expression.ConstantTemplate("")
-        one_template = '${"test_{}".format(a)}'
-        self.assertEqual(cons_tmpl.resolve_string(one_template, {"a": "1"}), "test_1")
-        ano_template = '${f"test_{a}"}'
-        self.assertEqual(cons_tmpl.resolve_template(ano_template, {"a": "2"}), "test_2")
+        format_attr_template = '${"test_{}".format(a)}'
+        self.assertEqual(cons_tmpl.resolve_string(format_attr_template, {"a": "1"}), format_attr_template)
+        percent_template = '${"test_%s" % a}'
+        self.assertEqual(cons_tmpl.resolve_string(percent_template, {"a": "1"}), "test_1")
+        fstring_template = '${f"test_{a}"}'
+        self.assertEqual(cons_tmpl.resolve_template(fstring_template, {"a": "2"}), "test_2")
 
     def test_resolve_string(self):
         cons_tmpl = expression.ConstantTemplate("")

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -16,8 +16,10 @@ import datetime
 
 from django.test import TestCase
 
-from pipeline.core.data import expression, sandbox
+from pipeline.core.data import expression, mako_safety, sandbox
 from pipeline.core.data.expression import format_constant_key, deformat_constant_key
+from pipeline.utils.mako_utils.checker import check_mako_template_safety
+from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
 class TestConstantTemplate(TestCase):
@@ -214,3 +216,151 @@ class TestConstantTemplate(TestCase):
             self.assertEqual(expression.ConstantTemplate(at).resolve_data({}), at)
 
         sandbox.SANDBOX = sandbox_copy
+
+
+class TestMakoNameWhitelist(TestCase):
+    def setUp(self):
+        from bamboo_engine.config import Settings as BambooSettings
+
+        self._BambooSettings = BambooSettings
+        self._original_mode = BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE
+        self._original_extra = BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
+    def tearDown(self):
+        self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = self._original_mode
+        self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = self._original_extra
+
+    def _set_mode(self, mode, extra=()):
+        self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
+        self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
+
+    def test_off_mode_keeps_legacy_behavior(self):
+        self._set_mode("off")
+        payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertIn("OFF", rendered)
+
+    def test_default_mode_blocks_self_module(self):
+        payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertEqual(rendered, payload)
+
+    def test_enforce_blocks_self_module(self):
+        self._set_mode("enforce")
+        payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertEqual(rendered, payload)
+
+    def test_dangerous_attr_chain_blocked(self):
+        self._set_mode("enforce")
+        original_imports = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {
+            "datetime": "datetime",
+            "re": "re",
+            "os.path": "os.path",
+        }
+        try:
+            payloads = [
+                '${os.path.os.popen("echo PWNED").read()}',
+                '${os.path.genericpath.os.popen("echo PWNED").read()}',
+                '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+                '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+            ]
+            for p in payloads:
+                with self.subTest(payload=p):
+                    rendered = expression.ConstantTemplate(p).resolve_data({})
+                    self.assertEqual(rendered, p)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+    def test_single_underscore_attr_blocked(self):
+        self._set_mode("enforce")
+        for p in [
+            "${context._kwargs}",
+            "${context._with_template}",
+            "${obj._secret}",
+        ]:
+            with self.subTest(payload=p):
+                rendered = expression.ConstantTemplate(p).resolve_data({"obj": object()})
+                self.assertEqual(rendered, p)
+
+    def test_business_patterns_still_render(self):
+        self._set_mode("enforce")
+        cases = [
+            ("${name.upper()}", {"name": "abc"}, "ABC"),
+            ("${[x * 2 for x in items]}", {"items": [1, 2, 3]}, "[2, 4, 6]"),
+            ("${(lambda y: y + 1)(seed)}", {"seed": 4}, "5"),
+            ("${len(items)}", {"items": [1, 2]}, "2"),
+        ]
+        for tpl, ctx, expected in cases:
+            with self.subTest(tpl=tpl):
+                self.assertEqual(expression.ConstantTemplate(tpl).resolve_data(ctx), expected)
+
+    def test_extra_whitelist_names(self):
+        self._set_mode("enforce", extra=("_loop", "_system"))
+        self.assertEqual(expression.ConstantTemplate("${_loop}").resolve_data({"_loop": 3}), 3)
+        self.assertEqual(expression.ConstantTemplate("${_loop + 1}").resolve_data({"_loop": 4}), "5")
+
+    def test_unknown_root_name_blocked(self):
+        self._set_mode("enforce")
+        payload = "${secret_var}"
+        self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+
+
+class TestMakoSafetyHardening(TestCase):
+    def _assert_forbidden(self, payload):
+        with self.assertRaises(ForbiddenMakoTemplateException):
+            check_mako_template_safety(
+                payload,
+                mako_safety.SingleLineNodeVisitor(),
+                mako_safety.SingleLinCodeExtractor(),
+            )
+
+    def _assert_allowed(self, payload):
+        check_mako_template_safety(
+            payload,
+            mako_safety.SingleLineNodeVisitor(),
+            mako_safety.SingleLinCodeExtractor(),
+        )
+
+    def test_filter_callable_with_side_effect_is_blocked(self):
+        self._assert_forbidden("${'x'|((side_effect() or str))}")
+
+    def test_filter_with_dunder_chain_is_blocked(self):
+        self._assert_forbidden("${'x'|().__class__.__bases__[0].__subclasses__}")
+
+    def test_filter_list_with_malicious_item_is_blocked(self):
+        self._assert_forbidden("${'x'|h, (side_effect() or str)}")
+
+    def test_decode_filter_with_dunder_is_blocked(self):
+        self._assert_forbidden("${'x'|decode.__class__}")
+
+    def test_tag_level_expression_filter_is_blocked(self):
+        self._assert_forbidden('<%page expression_filter="(side_effect() or str)"/>${name}')
+
+    def test_tag_level_def_filter_is_blocked(self):
+        payload = '<%def name="r(x)" filter="(side_effect() or str)">${x}</%def>${r("x")}'
+        self._assert_forbidden(payload)
+
+    def test_tag_level_block_filter_is_blocked(self):
+        self._assert_forbidden('<%block filter="(side_effect() or str)">x</%block>')
+
+    def test_tag_level_text_filter_is_blocked(self):
+        self._assert_forbidden('<%text filter="(side_effect() or str)">x</%text>')
+
+    def test_format_attribute_call_is_blocked(self):
+        self._assert_forbidden('${"{0.__class__}".format("")}')
+
+    def test_format_map_attribute_call_is_blocked(self):
+        self._assert_forbidden('${"{value.__class__}".format_map({"value": ""})}')
+
+    def test_builtin_filters_remain_allowed(self):
+        for payload in [
+            "${' x ' | h}",
+            "${' x ' | trim}",
+            "${' x ' | h, trim}",
+            "${'x' | n}",
+            "${b'abc' | decode.utf8}",
+        ]:
+            with self.subTest(payload=payload):
+                self._assert_allowed(payload)

--- a/runtime/bamboo-pipeline/pipeline/utils/mako_utils/checker.py
+++ b/runtime/bamboo-pipeline/pipeline/utils/mako_utils/checker.py
@@ -19,8 +19,19 @@ from mako import parsetree
 from mako.exceptions import MakoException
 from mako.lexer import Lexer
 
+from pipeline.core.data import mako_safety
+
 from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
+
+
+def validate_node_filter_callables(node: parsetree.Node):
+    # Mako stores inline `${expr | ...}` filter callables in `escapes_code`;
+    # tag-level filters use `filter_args`. Both are executed by create_filter_callable().
+    if hasattr(node, "escapes_code"):
+        mako_safety.validate_filter_args(node.escapes_code.args)
+    if hasattr(node, "filter_args"):
+        mako_safety.validate_filter_args(node.filter_args.args)
 
 
 def parse_template_nodes(
@@ -33,14 +44,15 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        code = code_extractor.extract(node)
-        if code is None:
-            continue
+        validate_node_filter_callables(node)
 
-        ast_node = ast.parse(code, "<unknown>", "exec")
-        node_visitor.visit(ast_node)
+        code = code_extractor.extract(node)
+        if code is not None:
+            ast_node = ast.parse(code, "<unknown>", "exec")
+            node_visitor.visit(ast_node)
+
         if hasattr(node, "nodes"):
-            parse_template_nodes(node.nodes, node_visitor)
+            parse_template_nodes(node.nodes, node_visitor, code_extractor)
 
 
 def check_mako_template_safety(text: str, node_visitor: ast.NodeVisitor, code_extractor: MakoNodeCodeExtractor) -> bool:

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -13,8 +13,14 @@ specific language governing permissions and limitations under the License.
 
 import datetime
 
+import pytest
+from mako.template import Template as MakoTemplate
+
 from bamboo_engine.config import Settings
 from bamboo_engine.template import Template
+from bamboo_engine.utils import mako_safety
+from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
+from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
 def test_get_reference():
@@ -110,3 +116,214 @@ def test_mako_attack():
     ]
     for at in attack_templates:
         assert Template(at).render({}) == at
+
+
+@pytest.fixture
+def whitelist_mode():
+    original_mode = Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE
+    original_extra = Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
+    def _set(mode, extra=()):
+        Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
+        Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
+
+    try:
+        yield _set
+    finally:
+        Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = original_mode
+        Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = original_extra
+
+
+def test_mako_self_module_namespace_executes_when_whitelist_off(whitelist_mode):
+    whitelist_mode("off")
+    payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
+    rendered = Template(payload).render({})
+    assert "OFF" in rendered
+
+
+def test_mako_whitelist_default_blocks_self_module_namespace():
+    payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+    assert Template(payload).render({}) == payload
+
+
+def _assert_forbidden_template(payload):
+    with pytest.raises(ForbiddenMakoTemplateException):
+        check_mako_template_safety(
+            payload,
+            mako_safety.SingleLineNodeVisitor(),
+            mako_safety.SingleLinCodeExtractor(),
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${self.module.cache.util.os.popen("echo PWNED").read()}',
+        "${context.lookup}",
+        "${local.something}",
+        "${parent.foo}",
+        "${caller.body()}",
+        "${pageargs.x}",
+    ],
+)
+def test_mako_whitelist_blocks_reserved_namespaces(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    assert Template(payload).render({}) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${os.path.os.popen("echo PWNED").read()}',
+        '${os.path.genericpath.os.popen("echo PWNED").read()}',
+        '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+        '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+        '${os.path.os.system("echo PWNED")}',
+    ],
+)
+def test_mako_whitelist_blocks_dangerous_attr_chain(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "re": "re",
+        "os.path": "os.path",
+    }
+    try:
+        rendered = Template({"x": payload}).render({})
+        assert rendered["x"] == payload
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${context._kwargs}",
+        "${context._with_template}",
+        "${context._data}",
+        "${obj._secret}",
+        "${obj.public._private}",
+    ],
+)
+def test_mako_whitelist_blocks_single_underscore_attr(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    rendered = Template({"x": payload}).render({"obj": object()})
+    assert rendered["x"] == payload
+
+
+def test_mako_whitelist_allows_business_patterns(whitelist_mode):
+    whitelist_mode("enforce")
+    cases = [
+        ("${name.upper()}", {"name": "abc"}, "ABC"),
+        ("${name.split('-')}", {"name": "a-b-c"}, "['a', 'b', 'c']"),
+        ("${[x * 2 for x in items]}", {"items": [1, 2, 3]}, "[2, 4, 6]"),
+        ("${(lambda y: y + 1)(seed)}", {"seed": 4}, "5"),
+        ("${a if a else 'default'}", {"a": ""}, "default"),
+        ("${len(items)}", {"items": [1, 2, 3]}, "3"),
+    ]
+    for tpl, ctx, expected in cases:
+        assert Template(tpl).render(ctx) == expected
+
+
+def test_mako_whitelist_allows_imported_modules(whitelist_mode):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "os.path": "os.path",
+    }
+    try:
+        assert Template('${os.path.join("a", "b")}').render({}) == "a/b"
+        out = Template('${datetime.datetime.now().strftime("%Y")}').render({})
+        assert len(out) == 4 and out.isdigit()
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+def test_mako_whitelist_extra_names_allowed(whitelist_mode):
+    whitelist_mode("enforce", extra=("_loop", "_system"))
+    assert Template("${_loop}").render({"_loop": 7}) == 7
+    assert Template("${_loop + 1}").render({"_loop": 2}) == "3"
+
+
+def test_mako_whitelist_unknown_root_name_is_blocked(whitelist_mode):
+    whitelist_mode("enforce")
+    payload = "${secret_var}"
+    assert Template(payload).render({}) == payload
+
+
+def test_mako_filter_side_effect_expression_is_blocked():
+    _assert_forbidden_template("${'x'|((side_effect() or str))}")
+
+
+def test_mako_filter_dunder_chain_is_blocked():
+    _assert_forbidden_template("${'x'|().__class__.__bases__[0].__subclasses__}")
+
+
+def test_mako_filter_list_blocks_any_malicious_item():
+    _assert_forbidden_template("${'x'|h, (side_effect() or str)}")
+
+
+def test_mako_decode_filter_private_attribute_is_blocked():
+    _assert_forbidden_template("${'x'|decode.__class__}")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '<%page expression_filter="(side_effect() or str)"/>${name}',
+        '<%def name="render_name(name)" filter="(side_effect() or str)">${name}</%def>${render_name("x")}',
+        '<%block filter="(side_effect() or str)">x</%block>',
+        '<%text filter="(side_effect() or str)">x</%text>',
+    ],
+)
+def test_mako_tag_filter_callables_are_blocked(payload):
+    _assert_forbidden_template(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${' x ' | h}",
+        "${' x ' | trim}",
+        "${' x ' | h, trim}",
+        "${'x' | n}",
+        "${b'abc' | decode.utf8}",
+    ],
+)
+def test_mako_builtin_filters_remain_allowed(payload):
+    check_mako_template_safety(
+        payload,
+        mako_safety.SingleLineNodeVisitor(),
+        mako_safety.SingleLinCodeExtractor(),
+    )
+
+
+def test_mako_builtin_filter_rendering_still_works():
+    assert MakoTemplate("${'x' | h}").render_unicode() == "x"
+    assert MakoTemplate("${' x ' | trim}").render_unicode() == "x"
+
+
+def test_mako_filter_side_effect_is_not_executed_by_template_render():
+    sentinel = {"called": False}
+
+    def side_effect():
+        sentinel["called"] = True
+        return str
+
+    payload = "${'x'|((side_effect() or str))}"
+
+    assert Template(payload).render({"side_effect": side_effect}) == payload
+    assert sentinel["called"] is False
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${"{0.__class__}".format("")}',
+        '${"{value.__class__}".format_map({"value": ""})}',
+    ],
+)
+def test_mako_format_private_lookup_is_blocked(payload):
+    _assert_forbidden_template(payload)


### PR DESCRIPTION
## Summary
- backport root-name whitelist protection for Mako reserved namespaces such as self/context/local
- harden Mako filter, tag-level filter, format/format_map, and dangerous attr-chain checks
- keep versions unchanged; release/package bump can be done after merge

## Validation
- uv run --no-project --python /Users/dengyh/.pyenv/versions/3.7.16/bin/python --with pytest==6.2.5 --with Mako==1.1.4 --with Werkzeug<2 --with pyparsing<3 --with prometheus-client==0.9.0 pytest -q tests/template/test_template.py
- uv run --no-project --python /Users/dengyh/.pyenv/versions/3.7.16/bin/python python -m compileall -q bamboo_engine runtime/bamboo-pipeline/pipeline/core/data runtime/bamboo-pipeline/pipeline/utils/mako_utils runtime/bamboo-pipeline/pipeline/conf
- runtime ConstantTemplate smoke script with minimal Django settings: blocks self.module, filter callable, and format lookup payloads

## Notes
- bk-sops master currently pins bamboo-pipeline==3.24.11. GitHub bamboo_pipeline_3.24_lts branch head is still at 3.24.10; this PR intentionally does not change package versions.