### PR TITLE
fix(engine): 阻止已撤销流程继续执行节点调度 --story=135505027

### DIFF
--- a/bamboo_engine/engine.py
+++ b/bamboo_engine/engine.py
@@ -1192,6 +1192,17 @@ class Engine:
                 )
                 return
 
+            root_state = self.runtime.batch_get_state_name([root_pipeline_id]).get(root_pipeline_id)
+            if root_state == states.REVOKED:
+                logger.info(
+                    "root pipeline[%s] schedule(%s) %s expired because root pipeline is revoked",
+                    root_pipeline_id,
+                    schedule_id,
+                    node_id,
+                )
+                self.runtime.expire_schedule(schedule_id)
+                return
+
             # 检查 schedule 是否过期
             version_mismatch = False
             if interrupter.recover_point and interrupter.recover_point.version_mismatch is not None:

--- a/tests/engine/test_engine_schedule.py
+++ b/tests/engine/test_engine_schedule.py
@@ -197,6 +197,33 @@ def test_schedule__schedule_is_finished(node_id, pi, schedule, interrupter):
     runtime.beat.assert_not_called()
 
 
+def test_schedule__root_pipeline_is_revoked(node_id, pi, state, schedule, node, interrupter):
+    runtime = MagicMock()
+    runtime.get_process_info = MagicMock(return_value=pi)
+    runtime.batch_get_state_name = MagicMock(return_value={pi.root_pipeline_id: states.REVOKED})
+    runtime.apply_schedule_lock = MagicMock(return_value=True)
+    runtime.get_schedule = MagicMock(return_value=schedule)
+    runtime.get_state = MagicMock(return_value=state)
+    runtime.get_node = MagicMock(return_value=node)
+
+    handler = MagicMock()
+    get_handler = MagicMock(return_value=handler)
+
+    engine = Engine(runtime=runtime)
+
+    with mock.patch(
+        "bamboo_engine.engine.HandlerFactory.get_handler",
+        get_handler,
+    ):
+        engine.schedule(pi.process_id, node_id, schedule.id, interrupter, headers={})
+
+    runtime.batch_get_state_name.assert_called_once_with([pi.root_pipeline_id])
+    runtime.expire_schedule.assert_called_once_with(schedule.id)
+    runtime.apply_schedule_lock.assert_not_called()
+    runtime.get_node.assert_not_called()
+    handler.schedule.assert_not_called()
+
+
 def test_schedule__schedule_version_not_match(node_id, pi, state, schedule, interrupter):
     state.version = "v2"
 


### PR DESCRIPTION
## 问题

根流程被撤销后，异步节点的调度入口只检查节点自身仍为 `RUNNING`，没有检查根流程已是 `REVOKED`。因此长定时、轮询和回调类节点仍可能在撤销后进入插件 `schedule`，并继续产生副作用。

## 修复

- 在 `Engine.schedule` 获取调度锁和调用插件前检查根流程状态。
- 根流程为 `REVOKED` 时将当前 schedule 标记为过期并立即返回。
- 不获取调度锁、不调用插件 handler，也不推进后续节点。
- 新增回归测试覆盖该中止路径。

## 影响范围

统一覆盖使用 bamboo-engine schedule 机制的定时、轮询和回调节点，不针对具体插件做特判。

## 验证

- `tests/engine/test_engine_schedule.py`: 14 passed
- `flake8 bamboo_engine/engine.py tests/engine/test_engine_schedule.py`: passed

## 联动

- BKFlow master 调试 PR：[BKFlow #768](https://github.com/TencentBlueKing/BKFlow/pull/768)
- BKFlow develop 集成 PR：[BKFlow #840](https://github.com/TencentBlueKing/BKFlow/pull/840)
