### PR TITLE
fix: 让 child_process_finish 对重复 ACK 幂等

### DIFF
--- a/runtime/bamboo-pipeline/pipeline/eri/imp/process.py
+++ b/runtime/bamboo-pipeline/pipeline/eri/imp/process.py
@@ -209,6 +209,9 @@ class ProcessMixin:
         """
         标记某个进程的子进程执行完成，并返回是否能够唤醒父进程继续执行的标志位
 
+        该接口应为幂等：同一子进程重复调用时不得再次增加父进程 ack_num，
+        否则消息重投会把陈旧 ACK 计入后续 fork 轮次，导致假唤醒或丢唤醒。
+
         :param parent_id: 父进程 ID
         :type parent_id: int
         :param process_id: 子进程 ID
@@ -217,7 +220,10 @@ class ProcessMixin:
         :rtype: bool
         """
         with transaction.atomic():
-            Process.objects.filter(id=process_id).update(dead=True)
+            # 子进程一生只允许合法 ACK 一次；dead 翻转失败说明是重复投递
+            finished = Process.objects.filter(id=process_id, dead=False).update(dead=True)
+            if not finished:
+                return False
 
             Process.objects.filter(id=parent_id).update(ack_num=F("ack_num") + 1)
 

--- a/runtime/bamboo-pipeline/pipeline/tests/eri/imp/test_process.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/eri/imp/test_process.py
@@ -176,6 +176,10 @@ class ProcessMixinTestCase(TransactionTestCase):
         need_ack = 30
 
         process = Process.objects.create(priority=1, queue="queue", ack_num=0, need_ack=need_ack)
+        children = [
+            Process.objects.create(priority=1, queue="queue", parent_id=process.id, dead=False)
+            for _ in range(need_ack)
+        ]
 
         lock = threading.Lock()
         res = {False: 0, True: 0}
@@ -186,7 +190,7 @@ class ProcessMixinTestCase(TransactionTestCase):
             res[success] += 1
             lock.release()
 
-        threads = [threading.Thread(target=target, args=(process.id, i)) for i in range(need_ack)]
+        threads = [threading.Thread(target=target, args=(process.id, child.id)) for child in children]
 
         for t in threads:
             t.start()
@@ -198,6 +202,59 @@ class ProcessMixinTestCase(TransactionTestCase):
         self.assertEqual(process.ack_num, 0)
         self.assertEqual(process.need_ack, -1)
         self.assertEqual(res, {True: 1, False: need_ack - 1})
+        for child in children:
+            child.refresh_from_db()
+            self.assertTrue(child.dead)
+
+    def test_child_process_finish_idempotent(self):
+        """同一子进程的重复 ACK 不得再次增加父进程 ack_num。"""
+        parent = Process.objects.create(priority=1, queue="queue", ack_num=0, need_ack=1)
+        child = Process.objects.create(priority=1, queue="queue", parent_id=parent.id, dead=False)
+
+        first = self.mixin.child_process_finish(parent.id, child.id)
+        parent.refresh_from_db()
+        child.refresh_from_db()
+        self.assertTrue(first)
+        self.assertTrue(child.dead)
+        self.assertEqual(parent.ack_num, 0)
+        self.assertEqual(parent.need_ack, -1)
+
+        # 模拟 broker 重投：子进程已 dead，再次 finish 必须是 no-op
+        second = self.mixin.child_process_finish(parent.id, child.id)
+        parent.refresh_from_db()
+        self.assertFalse(second)
+        self.assertEqual(parent.ack_num, 0)
+        self.assertEqual(parent.need_ack, -1)
+
+    def test_child_process_finish_stale_ack_across_fork_generations(self):
+        """陈旧 ACK 不得计入下一轮 fork 的 need_ack，避免假唤醒。"""
+        parent = Process.objects.create(priority=1, queue="queue", ack_num=0, need_ack=1)
+        child_a = Process.objects.create(priority=1, queue="queue", parent_id=parent.id, dead=False)
+
+        # 第一轮：合法 ACK，唤醒父进程
+        self.assertTrue(self.mixin.child_process_finish(parent.id, child_a.id))
+        parent.refresh_from_db()
+        self.assertEqual(parent.need_ack, -1)
+        self.assertEqual(parent.ack_num, 0)
+
+        # 第二轮：父进程 join 新的子进程 B
+        child_b = Process.objects.create(priority=1, queue="queue", parent_id=parent.id, dead=False)
+        self.mixin.join(parent.id, [child_b.id])
+        parent.refresh_from_db()
+        self.assertEqual(parent.need_ack, 1)
+        self.assertEqual(parent.ack_num, 0)
+
+        # 第一轮消息重投：陈旧 ACK 不得唤醒等待 B 的父进程
+        self.assertFalse(self.mixin.child_process_finish(parent.id, child_a.id))
+        parent.refresh_from_db()
+        self.assertEqual(parent.need_ack, 1)
+        self.assertEqual(parent.ack_num, 0)
+
+        # B 的真实 ACK 仍应正常唤醒
+        self.assertTrue(self.mixin.child_process_finish(parent.id, child_b.id))
+        parent.refresh_from_db()
+        self.assertEqual(parent.need_ack, -1)
+        self.assertEqual(parent.ack_num, 0)
 
     def test_is_frozen(self):
         self.assertFalse(self.mixin.is_frozen(self.process.id))


### PR DESCRIPTION
## Summary
- 修复 `ProcessMixin.child_process_finish`：仅在子进程 `dead=False→True` 翻转成功时增加父进程 `ack_num`，使重复 ACK（broker 消息重投）成为 no-op
- 对齐 ERI 接口文档中「该接口应为幂等接口」的约定，避免陈旧 ACK 串入后续 fork 轮次导致假唤醒 / 丢唤醒
- 补充幂等与跨代 fork 回归测试，并修正原并发测试使用不存在 `process_id` 的写法

## 背景
生产任务 `147341543` 排查确认：RabbitMQ 连接重置后，同一条子进程 destination execute 消息被消费两次。第二次 `child_process_finish` 仍会 `ack_num+1`，恰好凑满父进程正在等待的下一轮 `need_ack`，造成：
1. 父进程被假唤醒，汇聚网关下游整段重跑（真实重复下发作业）
2. 合法子进程的真实 ACK 撞上已被清零的计数，流程永久卡死（残留 `ack_num=1, need_ack=-1`）

## Test plan
- [ ] CI `pipeline-unittest` 通过（重点：`pipeline/tests/eri/imp/test_process.py`）
- [x] 本地 `py_compile` 通过（本机无可用 Django venv，单测依赖 CI）
- [ ] 评审确认：已 dead 子进程重复调用返回 `False` 且不改父进程计数
- [ ] 评审确认：跨代场景下陈旧 ACK 不会唤醒等待新子进程的父进程


Made with [Cursor](https://cursor.com)