### PR TITLE
fix(diagnostics): 收敛卡住误判——人工停车、失败停车、迟到回调残留、历史遗留 root（3.24.15）

### DIFF
--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "3.24.14"
+__version__ = "3.24.15"

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/conf.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/conf.py
@@ -42,6 +42,11 @@ def stall_threshold_seconds():
     return _get_setting("STALL_THRESHOLD_SECONDS", 1800)
 
 
+def scan_max_silent_seconds():
+    """周期扫描的静默上界，超过该时长的 root 视为历史遗留，不再进入取样池。0 表示不设上界。"""
+    return _get_setting("SCAN_MAX_SILENT_SECONDS", 7 * 24 * 3600)
+
+
 def scan_batch():
     return _get_setting("SCAN_BATCH", 200)
 

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/management/commands/scan_stuck_cases.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/management/commands/scan_stuck_cases.py
@@ -12,11 +12,19 @@ class Command(BaseCommand):
         parser.add_argument("--threshold", dest="threshold", type=int, default=None)
         parser.add_argument("--batch", dest="batch", type=int, default=None)
         parser.add_argument("--confirm", dest="confirm", type=int, default=None)
+        parser.add_argument(
+            "--max-silent",
+            dest="max_silent",
+            type=int,
+            default=None,
+            help="静默上界（秒），0 表示不设上界，用于一次性回扫历史积压",
+        )
 
     def handle(self, *args, **options):
         cases = scan_stalled_roots(
             threshold_seconds=options.get("threshold"),
             batch=options.get("batch"),
             confirm_seconds=options.get("confirm"),
+            max_silent_seconds=options.get("max_silent"),
         )
         self.stdout.write("upserted cases: {}".format(len(cases)))

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/progress.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/progress.py
@@ -24,15 +24,26 @@ def stall_cutoff(threshold_seconds, now=None):
     return now - timedelta(seconds=threshold_seconds)
 
 
-def stalled_root_candidates(threshold_seconds, batch, now=None):
-    """root 级 Max(last_heartbeat) 超阈值的存活流程，按最久静默升序。"""
+def stalled_root_candidates(threshold_seconds, batch, now=None, max_silent_seconds=None):
+    """root 级 Max(last_heartbeat) 落在 [now-max_silent, now-threshold) 的存活流程，按最近静默优先。
+
+    上界的作用：线上存在大量心跳停在数百天前的历史遗留 root（撤销、库迁移、早期版本残留），
+    没有上界时它们会长期占满 batch，导致刚刚静默的 root 永远排不进本轮取样（队头阻塞）。
+
+    排序方向为倒序：每一轮优先取刚跨过阈值的 root，保证新出现的停滞能被及时立案；
+    窗口内的历史积压交给一次性回扫处理，不占用周期任务的名额。
+    """
     cutoff = stall_cutoff(threshold_seconds, now=now)
+    queryset = Process.objects.filter(dead=False)
+    if max_silent_seconds:
+        # 先按行过滤再分组：root 的 Max 只可能来自 >= floor 的行，语义与分组后再判上界等价，
+        # 但能借 last_heartbeat 索引把参与分组的行数压下来。
+        queryset = queryset.filter(last_heartbeat__gte=stall_cutoff(max_silent_seconds, now=now))
     rows = (
-        Process.objects.filter(dead=False)
-        .values("root_pipeline_id")
+        queryset.values("root_pipeline_id")
         .annotate(latest=Max("last_heartbeat"))
         .filter(latest__lt=cutoff)
-        .order_by("latest")[:batch]
+        .order_by("-latest")[:batch]
     )
     return [(row["root_pipeline_id"], row["latest"]) for row in rows]
 

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
@@ -2,11 +2,14 @@
 
 from collections import defaultdict
 
+from bamboo_engine.eri import ScheduleType
+
 from pipeline.contrib.diagnostics.types import DiagnosticHit
 from pipeline.engine import states
 
 
 TERMINAL_STATES = frozenset([states.FINISHED, states.FAILED, states.REVOKED])
+CALLBACK_SCHEDULE_TYPES = frozenset([ScheduleType.CALLBACK.value, ScheduleType.MULTIPLE_CALLBACK.value])
 
 
 def _ids(items):
@@ -20,6 +23,31 @@ def _parked_by_user(process):
     此时它指向的下一个节点自然还没有 State，各类"进程活着但状态不对"的判据都会误判。
     """
     return bool(getattr(process, "suspended", False) or getattr(process, "frozen", False))
+
+
+def _schedule_type_value(schedule):
+    return getattr(schedule.type, "value", schedule.type)
+
+
+def _waiting_external_callback(snapshot, states_by_node, schedules_by_node):
+    """引擎正沉睡等待外部回调。
+
+    runtime.beat() 只在执行推进循环和 schedule() 内部调用，等回调期间进程两者都不执行，
+    心跳因此冻结在入睡那一刻。也就是说"心跳静默"是回调型节点的设计必然结果，
+    而不是停滞的证据——等人的暂停节点、审批节点更是没有任何合理的时长上界。
+    """
+    for process in snapshot.processes:
+        if process.dead or not process.current_node_id:
+            continue
+        state = states_by_node.get(process.current_node_id)
+        if state is None or state.name != states.RUNNING:
+            continue
+        for schedule in schedules_by_node.get(process.current_node_id, []):
+            if schedule.version != state.version or schedule.finished or schedule.expired:
+                continue
+            if _schedule_type_value(schedule) in CALLBACK_SCHEDULE_TYPES:
+                return True
+    return False
 
 
 def _parked_at_failed_node(process, state):
@@ -306,7 +334,11 @@ def diagnose_snapshot(snapshot, stall_seconds=None):
     hits.extend(_schedule_finished_but_process_not_exited(snapshot, processes_by_id))
     hits.extend(_multiple_sleep_process_for_node(processes_by_node))
 
-    if not hits and stall_seconds is not None:
+    if (
+        not hits
+        and stall_seconds is not None
+        and not _waiting_external_callback(snapshot, states_by_node, schedules_by_node)
+    ):
         hits = [_stalled_no_progress_hit(snapshot, stall_seconds)]
 
     if stall_seconds is not None:

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
@@ -13,6 +13,20 @@ def _ids(items):
     return [item.id for item in sorted(items, key=lambda item: item.id)]
 
 
+def _parked_by_user(process):
+    """暂停/冻结的进程按设计停在原地等人工恢复，不是卡住。
+
+    pause_pipeline / pause_node / freeze 只把 suspended | frozen 置位，进程既没死也不再往前推进，
+    此时它指向的下一个节点自然还没有 State，各类"进程活着但状态不对"的判据都会误判。
+    """
+    return bool(getattr(process, "suspended", False) or getattr(process, "frozen", False))
+
+
+def _parked_at_failed_node(process, state):
+    """节点失败后引擎会 sleep 进程并停在该 FAILED 节点，等待人工重试或跳过，不是卡住。"""
+    return state.name == states.FAILED and bool(getattr(process, "asleep", False))
+
+
 def _hit(hit_type, severity, confidence, evidence, related_objects, recommended_actions, forbidden_actions, message):
     return DiagnosticHit(
         type=hit_type,
@@ -107,6 +121,8 @@ def _schedule_lock_stuck(snapshot):
 def _missing_state_for_live_process(snapshot, states_by_node):
     hits = []
     for process in sorted(snapshot.processes, key=lambda item: item.id):
+        if _parked_by_user(process):
+            continue
         if not process.dead and process.current_node_id and process.current_node_id not in states_by_node:
             hits.append(
                 _hit(
@@ -133,7 +149,11 @@ def _process_alive_but_terminal_state(snapshot, states_by_node):
     hits = []
     for process in sorted(snapshot.processes, key=lambda item: item.id):
         state = states_by_node.get(process.current_node_id)
-        if state is not None and not process.dead and state.name in TERMINAL_STATES:
+        if state is None or process.dead:
+            continue
+        if _parked_by_user(process) or _parked_at_failed_node(process, state):
+            continue
+        if state.name in TERMINAL_STATES:
             hits.append(
                 _hit(
                     "process_alive_but_terminal_state",
@@ -154,6 +174,8 @@ def _process_alive_but_terminal_state(snapshot, states_by_node):
 def _parallel_ack_not_converged(snapshot):
     hits = []
     for process in sorted(snapshot.processes, key=lambda item: item.id):
+        if _parked_by_user(process):
+            continue
         if process.need_ack > 0 and 0 <= process.ack_num < process.need_ack:
             hits.append(
                 _hit(
@@ -204,6 +226,8 @@ def _schedule_finished_but_process_not_exited(snapshot, processes_by_id):
     hits = []
     for schedule in sorted(snapshot.schedules, key=lambda item: item.id):
         process = processes_by_id.get(schedule.process_id)
+        if process is not None and _parked_by_user(process):
+            continue
         if (
             process is not None
             and schedule.finished

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
@@ -29,6 +29,25 @@ def _schedule_type_value(schedule):
     return getattr(schedule.type, "value", schedule.type)
 
 
+def _waiting_ack_convergence(process):
+    """并行网关把自己置为 FINISHED 后让父进程沉睡等子进程收敛，守在终态节点上是设计内行为。"""
+    return process.need_ack > 0 and 0 <= process.ack_num < process.need_ack
+
+
+def _live_children_count(snapshot):
+    counts = defaultdict(int)
+    for process in snapshot.processes:
+        parent_id = getattr(process, "parent_id", -1)
+        if not process.dead and parent_id not in (None, -1):
+            counts[parent_id] += 1
+    return counts
+
+
+def _has_full_process_view(snapshot):
+    """快照是否按 root 全量收集：只有此时子进程才在其中，才能判断收敛是否真的丢了。"""
+    return not snapshot.node_id and snapshot.process_id is None
+
+
 def _waiting_external_callback(snapshot, states_by_node, schedules_by_node):
     """引擎正沉睡等待外部回调。
 
@@ -202,6 +221,9 @@ def _process_alive_but_terminal_state(snapshot, states_by_node):
             continue
         if _parked_by_user(process) or _parked_at_failed_node(process, state):
             continue
+        if _waiting_ack_convergence(process):
+            # 收敛是否真的丢了由 parallel_ack_not_converged 判断，这里不重复报同一个根因
+            continue
         if state.name in TERMINAL_STATES:
             hits.append(
                 _hit(
@@ -221,30 +243,81 @@ def _process_alive_but_terminal_state(snapshot, states_by_node):
 
 
 def _parallel_ack_not_converged(snapshot):
+    """父进程等不到子进程的 ACK。
+
+    子进程还活着时未收敛是并行流程的正常形态，问题（如果有）在子进程身上，会被它自己的签名抓到，
+    报父进程只会把诊断指向错误的位置。只有子进程全都没了却仍未收敛，才是真的收敛丢失。
+    """
+    if not _has_full_process_view(snapshot):
+        return []
+
+    live_children = _live_children_count(snapshot)
     hits = []
     for process in sorted(snapshot.processes, key=lambda item: item.id):
-        if _parked_by_user(process):
+        if _parked_by_user(process) or not _waiting_ack_convergence(process):
             continue
-        if process.need_ack > 0 and 0 <= process.ack_num < process.need_ack:
-            hits.append(
-                _hit(
-                    "parallel_ack_not_converged",
-                    "high",
-                    0.94,
-                    {
-                        "process_id": process.id,
-                        "node_id": process.current_node_id,
-                        "ack_num": process.ack_num,
-                        "need_ack": process.need_ack,
-                    },
-                    {"process_id": process.id, "node_id": process.current_node_id},
-                    ["inspect_ack_converge"],
-                    ["resend_schedule", "replay_callback_data"],
-                    "Process {} waits for ACK convergence: {}/{}".format(
-                        process.id, process.ack_num, process.need_ack
-                    ),
-                )
+        if live_children.get(process.id, 0) > 0:
+            continue
+        hits.append(
+            _hit(
+                "parallel_ack_not_converged",
+                "high",
+                0.94,
+                {
+                    "process_id": process.id,
+                    "node_id": process.current_node_id,
+                    "ack_num": process.ack_num,
+                    "need_ack": process.need_ack,
+                    "live_children": 0,
+                },
+                {"process_id": process.id, "node_id": process.current_node_id},
+                ["inspect_ack_converge"],
+                ["resend_schedule", "replay_callback_data"],
+                "Process {} waits for ACK convergence: {}/{} while no child process is alive".format(
+                    process.id, process.ack_num, process.need_ack
+                ),
             )
+        )
+    return hits
+
+
+def _schedule_missing_for_running_node(snapshot, states_by_node, schedules_by_node):
+    """节点还在 RUNNING、有存活进程守着，却没有对应 version 的调度记录。
+
+    沉睡的进程只能由调度或回调唤醒，没有调度记录就是确定性地不可唤醒；未沉睡的多数是
+    celery worker 在 execute 途中被杀（OOM / 发布 / 驱逐），状态停在 RUNNING、调度还没写。
+    两者都不会再自行往前走，但后者与"execute 仍在执行"签名重合，因此本判据只在已确认静默时生效。
+    """
+    hits = []
+    for process in sorted(snapshot.processes, key=lambda item: item.id):
+        if process.dead or not process.current_node_id or _parked_by_user(process):
+            continue
+        state = states_by_node.get(process.current_node_id)
+        if state is None or state.name != states.RUNNING:
+            continue
+        versions = {schedule.version for schedule in schedules_by_node.get(process.current_node_id, [])}
+        if state.version in versions:
+            continue
+        asleep = bool(getattr(process, "asleep", False))
+        hits.append(
+            _hit(
+                "schedule_missing_for_running_node",
+                "critical",
+                0.90,
+                {
+                    "process_id": process.id,
+                    "node_id": process.current_node_id,
+                    "version": state.version,
+                    "process_asleep": asleep,
+                },
+                {"process_id": process.id, "node_id": process.current_node_id},
+                ["inspect_node_runtime_readiness"],
+                ["resend_schedule", "replay_callback_data"],
+                "Node {} is running without schedule for version {} while process {} stays on it (asleep={})".format(
+                    process.current_node_id, state.version, process.id, asleep
+                ),
+            )
+        )
     return hits
 
 
@@ -333,6 +406,10 @@ def diagnose_snapshot(snapshot, stall_seconds=None):
     hits.extend(_parallel_ack_not_converged(snapshot))
     hits.extend(_schedule_finished_but_process_not_exited(snapshot, processes_by_id))
     hits.extend(_multiple_sleep_process_for_node(processes_by_node))
+
+    if stall_seconds is not None:
+        # 需要"已确认静默"作为前置，否则会把 execute 正在执行的瞬时窗口当成异常
+        hits.extend(_schedule_missing_for_running_node(snapshot, states_by_node, schedules_by_node))
 
     if (
         not hits

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
@@ -63,11 +63,31 @@ def _build_indexes(snapshot):
     return processes_by_id, processes_by_node, states_by_node, schedules_by_node, callbacks_by_node
 
 
-def _callback_lock_conflicts(schedules_by_node, callbacks_by_node):
+def _callback_lock_conflicts(schedules_by_node, callbacks_by_node, states_by_node):
+    """回调数据多于调度次数，说明有回调没被消费掉，节点会一直等在那里。
+
+    只在节点还没到终态、且只统计当前 version 的数据时才成立：
+
+    - 终态节点上多出来的回调数据是迟到回调留下的残留。callback() 只校验"有沉睡进程 + version 一致 +
+      schedule 未完成"，而节点失败后进程恰好是沉睡在该节点上、version 也不变，迟到的回调因此能写进
+      CallbackData，随后调度任务发现节点已不是 RUNNING 就直接 expire 返回，schedule_times 不会自增。
+    - Schedule 是按 (node_id, version) 唯一的，跨 version 求和会让重试前残留的回调把总数顶起来，
+      而历史 version 的回调按定义挡不住当前 version 的调度。
+    """
     hits = []
     for node_id in sorted(set(schedules_by_node.keys()) | set(callbacks_by_node.keys())):
-        schedules = sorted(schedules_by_node.get(node_id, []), key=lambda schedule: schedule.id)
-        callbacks = sorted(callbacks_by_node.get(node_id, []), key=lambda callback_data: callback_data.id)
+        state = states_by_node.get(node_id)
+        if state is not None and state.name in TERMINAL_STATES:
+            continue
+        version = state.version if state is not None else None
+        schedules = sorted(
+            [item for item in schedules_by_node.get(node_id, []) if version is None or item.version == version],
+            key=lambda schedule: schedule.id,
+        )
+        callbacks = sorted(
+            [item for item in callbacks_by_node.get(node_id, []) if version is None or item.version == version],
+            key=lambda callback_data: callback_data.id,
+        )
         schedule_times = sum(schedule.schedule_times for schedule in schedules)
         if callbacks and len(callbacks) > schedule_times:
             hits.append(
@@ -77,6 +97,7 @@ def _callback_lock_conflicts(schedules_by_node, callbacks_by_node):
                     0.99,
                     {
                         "node_id": node_id,
+                        "version": version or "",
                         "callback_data_count": len(callbacks),
                         "schedule_times": schedule_times,
                     },
@@ -277,7 +298,7 @@ def diagnose_snapshot(snapshot, stall_seconds=None):
     processes_by_id, processes_by_node, states_by_node, schedules_by_node, callbacks_by_node = _build_indexes(snapshot)
 
     hits = []
-    hits.extend(_callback_lock_conflicts(schedules_by_node, callbacks_by_node))
+    hits.extend(_callback_lock_conflicts(schedules_by_node, callbacks_by_node, states_by_node))
     hits.extend(_missing_state_for_live_process(snapshot, states_by_node))
     hits.extend(_process_alive_but_terminal_state(snapshot, states_by_node))
     hits.extend(_schedule_lock_stuck(snapshot))

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/scanner.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/scanner.py
@@ -20,15 +20,16 @@ def _node_id_for_hit(hit, fallback_node_id=""):
     return hit.related_objects.get("node_id") or hit.evidence.get("node_id") or fallback_node_id or ""
 
 
-def scan_stalled_roots(threshold_seconds=None, batch=None, confirm_seconds=None, now=None):
+def scan_stalled_roots(threshold_seconds=None, batch=None, confirm_seconds=None, now=None, max_silent_seconds=None):
     if not conf.scan_enabled():
         return []
 
     threshold_seconds = threshold_seconds if threshold_seconds is not None else conf.stall_threshold_seconds()
     batch = batch if batch is not None else conf.scan_batch()
     confirm_seconds = confirm_seconds if confirm_seconds is not None else conf.second_confirm_seconds()
+    max_silent_seconds = max_silent_seconds if max_silent_seconds is not None else conf.scan_max_silent_seconds()
 
-    candidates = stalled_root_candidates(threshold_seconds, batch, now=now)
+    candidates = stalled_root_candidates(threshold_seconds, batch, now=now, max_silent_seconds=max_silent_seconds)
     if confirm_seconds and candidates:
         time.sleep(confirm_seconds)  # 一次性等待后统一二次确认，剔除刚恢复的 root
 

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_conf.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_conf.py
@@ -8,6 +8,11 @@ class ConfDefaultsTest(TestCase):
         self.assertEqual(conf.stall_threshold_seconds(), 1800)
         self.assertEqual(conf.scan_batch(), 200)
         self.assertEqual(conf.second_confirm_seconds(), 3)
+        self.assertEqual(conf.scan_max_silent_seconds(), 7 * 24 * 3600)
+
+    @override_settings(PIPELINE_DIAGNOSTICS_SCAN_MAX_SILENT_SECONDS=0)
+    def test_max_silent_can_be_disabled(self):
+        self.assertEqual(conf.scan_max_silent_seconds(), 0)
 
     def test_apply_disabled_by_default(self):
         self.assertFalse(conf.apply_enabled())

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_progress.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_progress.py
@@ -47,12 +47,37 @@ class ProgressTest(TransactionTestCase):
         roots = [r for r, _ in progress.stalled_root_candidates(1800, 100, now=now)]
         self.assertNotIn("root-multi", roots)  # M1 已知限制：root 级 Max 掩盖单条卡住分支
 
-    def test_candidates_sorted_oldest_first(self):
+    def test_candidates_sorted_recently_stalled_first(self):
         now = timezone.now()
         _proc("root-a", beat=now - timedelta(seconds=2000))
         _proc("root-b", beat=now - timedelta(seconds=5000))
         roots = [r for r, _ in progress.stalled_root_candidates(1800, 100, now=now)]
-        self.assertEqual(roots[0], "root-b")  # 最久静默优先
+        self.assertEqual(roots[0], "root-a")  # 刚跨过阈值的优先，避免历史积压占满 batch
+
+    def test_max_silent_seconds_excludes_ancient_roots(self):
+        now = timezone.now()
+        _proc("root-recent", beat=now - timedelta(seconds=3600))
+        _proc("root-ancient", beat=now - timedelta(days=400))
+
+        roots = [r for r, _ in progress.stalled_root_candidates(1800, 100, now=now, max_silent_seconds=7 * 24 * 3600)]
+        self.assertEqual(roots, ["root-recent"])
+
+    def test_ancient_roots_kept_when_bound_disabled(self):
+        now = timezone.now()
+        _proc("root-ancient", beat=now - timedelta(days=400))
+
+        roots = [r for r, _ in progress.stalled_root_candidates(1800, 100, now=now, max_silent_seconds=0)]
+        self.assertEqual(roots, ["root-ancient"])
+
+    def test_batch_is_not_exhausted_by_ancient_roots(self):
+        """上界的核心目的：历史积压不再挤掉刚静默的 root。"""
+        now = timezone.now()
+        for index in range(3):
+            _proc("root-ancient-{}".format(index), beat=now - timedelta(days=300 + index))
+        _proc("root-new", beat=now - timedelta(seconds=1900))
+
+        roots = [r for r, _ in progress.stalled_root_candidates(1800, 1, now=now, max_silent_seconds=7 * 24 * 3600)]
+        self.assertEqual(roots, ["root-new"])
 
     def test_root_last_progress(self):
         now = timezone.now()

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules.py
@@ -77,6 +77,10 @@ class DiagnosticRulesTestCase(TransactionTestCase):
     def _snapshot(self, root_pipeline_id="root-rules", node_id="node-rules", process_id=None):
         return collect_runtime_snapshot(root_pipeline_id=root_pipeline_id, node_id=node_id, process_id=process_id)
 
+    def _root_snapshot(self, root_pipeline_id="root-rules"):
+        """按 root 全量收集：只有这样子进程才在快照里，才能判断 ACK 收敛是否真的丢了。"""
+        return collect_runtime_snapshot(root_pipeline_id=root_pipeline_id)
+
     def _assert_hit_complete(self, hit, stuck_type):
         self.assertEqual(hit.type, stuck_type)
         self.assertTrue(hit.severity)
@@ -245,15 +249,73 @@ class DiagnosticRulesTestCase(TransactionTestCase):
         self._create_process(119, ack_num=1, need_ack=3, suspended=True, suspended_by="root-rules")
         self._create_state("node-rules")
 
-        hits = diagnose_snapshot(self._snapshot())
+        hits = diagnose_snapshot(self._root_snapshot())
 
         self.assertEqual(hits, [])
+
+    def test_parallel_ack_not_reported_while_children_alive(self):
+        """并行网关把自己置为 FINISHED 后让父进程沉睡等收敛，子进程还在跑就是正常形态。"""
+        parent = self._create_process(130, node_id="gateway-node", ack_num=1, need_ack=3, asleep=True)
+        self._create_process(131, node_id="child-node", parent_id=parent.id, dead=False, asleep=False)
+        self._create_state("gateway-node", name=states.FINISHED)
+        self._create_state("child-node", name=states.RUNNING)
+
+        hits = diagnose_snapshot(self._root_snapshot())
+
+        self.assertEqual(hits, [])
+
+    def test_parallel_ack_reported_when_all_children_dead(self):
+        parent = self._create_process(132, node_id="gateway-node", ack_num=0, need_ack=2, asleep=True)
+        self._create_process(133, node_id="child-node", parent_id=parent.id, dead=True)
+        self._create_state("gateway-node", name=states.FINISHED)
+
+        hits = diagnose_snapshot(self._root_snapshot())
+
+        self.assertEqual([hit.type for hit in hits], ["parallel_ack_not_converged"])
+        self.assertEqual(hits[0].evidence["live_children"], 0)
+        self.assertEqual(hits[0].related_objects["process_id"], parent.id)
+
+    def test_schedule_missing_for_running_node_reported_for_both_asleep_states(self):
+        """沉睡的确定不可唤醒；未沉睡的多是 worker 在 execute 途中被杀，同样不会再往前走。"""
+        for index, asleep in enumerate((True, False)):
+            with self.subTest(asleep=asleep):
+                node_id = "node-missing-{}".format(index)
+                process = self._create_process(140 + index, node_id=node_id, dead=False, asleep=asleep)
+                self._create_state(node_id, name=states.RUNNING)
+
+                hits = diagnose_snapshot(
+                    collect_runtime_snapshot(root_pipeline_id="root-rules", node_id=node_id), stall_seconds=3600
+                )
+
+                self.assertEqual([hit.type for hit in hits], ["schedule_missing_for_running_node"])
+                self.assertEqual(hits[0].evidence["process_asleep"], asleep)
+                self.assertEqual(hits[0].related_objects["process_id"], process.id)
+
+    def test_schedule_missing_not_reported_without_confirmed_stall(self):
+        """没有确认静默时不报，避免把 execute 正在执行的瞬时窗口当成异常。"""
+        self._create_process(142, node_id="node-missing-x", dead=False, asleep=False)
+        self._create_state("node-missing-x", name=states.RUNNING)
+
+        hits = diagnose_snapshot(collect_runtime_snapshot(root_pipeline_id="root-rules", node_id="node-missing-x"))
+
+        self.assertEqual(hits, [])
+
+    def test_schedule_missing_not_reported_when_current_version_has_schedule(self):
+        process = self._create_process(143, node_id="node-missing-y", dead=False, asleep=True)
+        self._create_state("node-missing-y", name=states.RUNNING, version="v9")
+        self._create_schedule(143, process.id, "node-missing-y", version="v9")
+
+        hits = diagnose_snapshot(
+            collect_runtime_snapshot(root_pipeline_id="root-rules", node_id="node-missing-y"), stall_seconds=3600
+        )
+
+        self.assertEqual([hit.type for hit in hits], [])
 
     def test_parallel_ack_not_converged(self):
         process = self._create_process(105, ack_num=1, need_ack=3)
         self._create_state("node-rules")
 
-        hits = diagnose_snapshot(self._snapshot())
+        hits = diagnose_snapshot(self._root_snapshot())
 
         self.assertEqual([hit.type for hit in hits], ["parallel_ack_not_converged"])
         self._assert_hit_complete(hits[0], "parallel_ack_not_converged")

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules.py
@@ -110,6 +110,47 @@ class DiagnosticRulesTestCase(TransactionTestCase):
         self.assertEqual(hits[0].evidence["schedule_times"], 1)
         self.assertEqual(hits[0].related_objects["schedule_ids"], [schedule.id])
 
+    def test_callback_lock_conflict_not_reported_for_terminal_node(self):
+        """JOB 节点失败后迟到的回调会写入 CallbackData 但不会自增 schedule_times，属于残留。"""
+        process = self._create_process(121, dead=False, asleep=True)
+        self._create_state("node-rules", name=states.FAILED)
+        self._create_schedule(121, process.id, "node-rules", schedule_times=1, expired=True)
+        self._create_callback_data("node-rules", callback_data_id=121)
+        self._create_callback_data("node-rules", callback_data_id=122)
+
+        hits = diagnose_snapshot(self._snapshot())
+
+        self.assertEqual(hits, [])
+
+    def test_callback_lock_conflict_ignores_stale_version_residue(self):
+        """节点重试后老 version 的回调残留挡不住当前 version 的调度。"""
+        process = self._create_process(122, dead=False)
+        self._create_state("node-rules", name=states.RUNNING, version="v2")
+        self._create_schedule(122, process.id, "node-rules", version="v1", schedule_times=1, expired=True)
+        self._create_schedule(123, process.id, "node-rules", version="v2", schedule_times=1)
+        self._create_callback_data("node-rules", version="v1", callback_data_id=123)
+        self._create_callback_data("node-rules", version="v1", callback_data_id=124)
+        self._create_callback_data("node-rules", version="v2", callback_data_id=125)
+
+        hits = diagnose_snapshot(self._snapshot())
+
+        self.assertEqual([hit.type for hit in hits], [])
+
+    def test_callback_lock_conflict_reported_for_running_node(self):
+        """回调写了但调度一次都没跑起来，节点会一直等着，仍然要报。"""
+        process = self._create_process(123, dead=False)
+        self._create_state("node-rules", name=states.RUNNING)
+        self._create_schedule(124, process.id, "node-rules", schedule_times=0)
+        self._create_callback_data("node-rules", callback_data_id=126)
+
+        hits = diagnose_snapshot(self._snapshot())
+
+        self.assertIn("callback_lock_conflict", [hit.type for hit in hits])
+        conflict = [hit for hit in hits if hit.type == "callback_lock_conflict"][0]
+        self.assertEqual(conflict.evidence["callback_data_count"], 1)
+        self.assertEqual(conflict.evidence["schedule_times"], 0)
+        self.assertEqual(conflict.evidence["version"], "v1")
+
     def test_schedule_lock_stuck(self):
         process = self._create_process(102)
         self._create_state("node-rules")

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules.py
@@ -132,6 +132,36 @@ class DiagnosticRulesTestCase(TransactionTestCase):
         self._assert_hit_complete(hits[0], "missing_state_for_live_process")
         self.assertEqual(hits[0].related_objects["process_id"], process.id)
 
+    def test_missing_state_not_reported_for_suspended_process(self):
+        """用户暂停整条流程时，进程停在还没建 State 的下一个节点上，不算卡住。"""
+        self._create_process(
+            113,
+            node_id="node-without-state",
+            dead=False,
+            suspended=True,
+            suspended_by="root-rules",
+        )
+
+        hits = diagnose_snapshot(collect_runtime_snapshot(root_pipeline_id="root-rules", node_id="node-without-state"))
+
+        self.assertEqual(hits, [])
+
+    def test_missing_state_not_reported_for_frozen_process(self):
+        self._create_process(114, node_id="node-without-state", dead=False, frozen=True)
+
+        hits = diagnose_snapshot(collect_runtime_snapshot(root_pipeline_id="root-rules", node_id="node-without-state"))
+
+        self.assertEqual(hits, [])
+
+    def test_missing_state_still_reported_for_asleep_process(self):
+        """asleep 不等于人工停车，仍然要报出来。"""
+        process = self._create_process(115, node_id="node-without-state", dead=False, asleep=True)
+
+        hits = diagnose_snapshot(collect_runtime_snapshot(root_pipeline_id="root-rules", node_id="node-without-state"))
+
+        self.assertEqual([hit.type for hit in hits], ["missing_state_for_live_process"])
+        self.assertEqual(hits[0].related_objects["process_id"], process.id)
+
     def test_process_alive_but_terminal_state(self):
         process = self._create_process(104, dead=False)
         self._create_state("node-rules", name=states.FINISHED)
@@ -142,6 +172,41 @@ class DiagnosticRulesTestCase(TransactionTestCase):
         self._assert_hit_complete(hits[0], "process_alive_but_terminal_state")
         self.assertEqual(hits[0].evidence["state"], states.FINISHED)
         self.assertEqual(hits[0].related_objects["process_id"], process.id)
+
+    def test_terminal_state_not_reported_for_failed_node_parking(self):
+        """节点失败后引擎会 sleep 进程停在 FAILED 节点等人工，是设计内行为。"""
+        self._create_process(116, dead=False, asleep=True)
+        self._create_state("node-rules", name=states.FAILED)
+
+        hits = diagnose_snapshot(self._snapshot())
+
+        self.assertEqual(hits, [])
+
+    def test_terminal_state_still_reported_for_awake_process_on_failed_node(self):
+        """停在 FAILED 节点但没睡，说明不是正常停车。"""
+        process = self._create_process(117, dead=False, asleep=False)
+        self._create_state("node-rules", name=states.FAILED)
+
+        hits = diagnose_snapshot(self._snapshot())
+
+        self.assertEqual([hit.type for hit in hits], ["process_alive_but_terminal_state"])
+        self.assertEqual(hits[0].related_objects["process_id"], process.id)
+
+    def test_terminal_state_not_reported_for_suspended_process(self):
+        self._create_process(118, dead=False, suspended=True, suspended_by="root-rules")
+        self._create_state("node-rules", name=states.FINISHED)
+
+        hits = diagnose_snapshot(self._snapshot())
+
+        self.assertEqual(hits, [])
+
+    def test_parallel_ack_not_reported_for_suspended_process(self):
+        self._create_process(119, ack_num=1, need_ack=3, suspended=True, suspended_by="root-rules")
+        self._create_state("node-rules")
+
+        hits = diagnose_snapshot(self._snapshot())
+
+        self.assertEqual(hits, [])
 
     def test_parallel_ack_not_converged(self):
         process = self._create_process(105, ack_num=1, need_ack=3)
@@ -177,6 +242,15 @@ class DiagnosticRulesTestCase(TransactionTestCase):
         self._assert_hit_complete(hits[0], "schedule_finished_but_process_not_exited")
         self.assertEqual(hits[0].related_objects["process_id"], process.id)
         self.assertEqual(hits[0].related_objects["schedule_id"], schedule.id)
+
+    def test_schedule_finished_not_reported_for_suspended_process(self):
+        process = self._create_process(120, dead=False, suspended=True, suspended_by="root-rules")
+        self._create_state("node-rules")
+        self._create_schedule(120, process.id, "node-rules", finished=True)
+
+        hits = diagnose_snapshot(self._snapshot())
+
+        self.assertEqual(hits, [])
 
     def test_healthy_snapshot_returns_empty(self):
         process = self._create_process(109, asleep=False, dead=False, ack_num=0, need_ack=-1)

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules_stall.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules_stall.py
@@ -94,10 +94,12 @@ def test_fallback_hit_when_callback_schedule_expired():
     assert [hit.type for hit in diagnose_snapshot(snapshot, stall_seconds=7200)] == ["stalled_no_progress"]
 
 
-def test_fallback_hit_when_running_node_has_no_schedule():
-    """RUNNING 但没有调度记录：没有任何机制会再唤醒它，必须保留。"""
+def test_running_node_without_schedule_gets_dedicated_hit():
+    """RUNNING 但没有调度记录：没有任何机制会再唤醒它，由专属判据接管而非走兜底。"""
     snapshot = _waiting_snapshot(ScheduleType.CALLBACK, with_schedule=False)
-    assert [hit.type for hit in diagnose_snapshot(snapshot, stall_seconds=7200)] == ["stalled_no_progress"]
+    hits = diagnose_snapshot(snapshot, stall_seconds=7200)
+    assert [hit.type for hit in hits] == ["schedule_missing_for_running_node"]
+    assert hits[0].evidence["stall_seconds"] == 7200
 
 
 def test_fallback_stalled_hit_when_no_specific_rule():

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules_stall.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules_stall.py
@@ -2,8 +2,11 @@
 
 import types
 
+from bamboo_engine.eri import ScheduleType
+
 from pipeline.contrib.diagnostics.rules import diagnose_snapshot
 from pipeline.contrib.diagnostics.types import RuntimeSnapshot
+from pipeline.engine import states as engine_states
 
 
 def _empty_snapshot(root="root-1", node="n1"):
@@ -37,6 +40,64 @@ def _snapshot_with_locked_schedule(root="root-1", node="n1"):
         schedules=[schedule],
         callback_data=[],
     )
+
+
+def _waiting_snapshot(schedule_type, node="n1", finished=False, expired=False, with_schedule=True):
+    """一个存活进程沉睡在 RUNNING 节点上，按调度类型决定它在等什么。"""
+    process = types.SimpleNamespace(id=1, current_node_id=node, dead=False, asleep=True, need_ack=-1, ack_num=0)
+    state = types.SimpleNamespace(id=1, node_id=node, name=engine_states.RUNNING, version="v1")
+    schedules = []
+    if with_schedule:
+        schedules.append(
+            types.SimpleNamespace(
+                id=1,
+                node_id=node,
+                process_id=1,
+                type=schedule_type,
+                version="v1",
+                scheduling=False,
+                finished=finished,
+                expired=expired,
+                schedule_times=0,
+            )
+        )
+    return RuntimeSnapshot(
+        root_pipeline_id="root-1",
+        node_id="",
+        process_id=None,
+        processes=[process],
+        states=[state],
+        schedules=schedules,
+        callback_data=[],
+    )
+
+
+def test_no_fallback_when_waiting_external_callback():
+    """等回调期间进程沉睡不 beat，心跳静默是设计必然，不该判为停滞。"""
+    assert diagnose_snapshot(_waiting_snapshot(ScheduleType.CALLBACK), stall_seconds=7200) == []
+
+
+def test_no_fallback_when_waiting_multiple_callback():
+    # DB 里 type 存的是 int，规则要能同时吃 int 和枚举
+    snapshot = _waiting_snapshot(ScheduleType.MULTIPLE_CALLBACK.value)
+    assert diagnose_snapshot(snapshot, stall_seconds=7200) == []
+
+
+def test_fallback_hit_for_poll_schedule():
+    """POLL 每次轮询都会 beat，静默说明轮询已经停了，要报。"""
+    hits = diagnose_snapshot(_waiting_snapshot(ScheduleType.POLL), stall_seconds=7200)
+    assert [hit.type for hit in hits] == ["stalled_no_progress"]
+
+
+def test_fallback_hit_when_callback_schedule_expired():
+    snapshot = _waiting_snapshot(ScheduleType.CALLBACK, expired=True)
+    assert [hit.type for hit in diagnose_snapshot(snapshot, stall_seconds=7200)] == ["stalled_no_progress"]
+
+
+def test_fallback_hit_when_running_node_has_no_schedule():
+    """RUNNING 但没有调度记录：没有任何机制会再唤醒它，必须保留。"""
+    snapshot = _waiting_snapshot(ScheduleType.CALLBACK, with_schedule=False)
+    assert [hit.type for hit in diagnose_snapshot(snapshot, stall_seconds=7200)] == ["stalled_no_progress"]
 
 
 def test_fallback_stalled_hit_when_no_specific_rule():

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "3.24.14"
+version = "3.24.15"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"


### PR DESCRIPTION
## 背景

现网对全量历史任务做了一次 Layer0 + 补充检测回扫，产出 8.1 万条命中。逐类抽样核实后发现五类系统性误判，本 PR 逐条收敛，每一条改动都有对应的现网数据支撑。

判据的共同问题是只看了引擎的一部分状态位，把"引擎按设计停在原地"和"引擎真的推不动了"混为一谈。

| 命中类型 | 核实样本 | 误判 | 真信号 |
| --- | --- | --- | --- |
| `missing_state_for_live_process` | 56 | 53（人工暂停） | 3 |
| `process_alive_but_terminal_state`（FINISHED） | 4268 | 4251（网关等收敛）+ 12（人工停车） | 4 |
| `process_alive_but_terminal_state`（FAILED） | 大量 | 失败停车等人工 | 停在 FAILED 但没睡的 |
| `callback_lock_conflict` | 25 | 24（迟到回调残留） | 1 |
| `stalled_no_progress` | 370 | 348（等外部回调） | 20（无调度记录） |
| `parallel_ack_not_converged` | 4251 | 4251（子进程仍存活） | 0 |

## 改动

### 1. 人工停车的进程不再判为卡住

`missing_state_for_live_process` 命中 56 条（按 process 去重）：`suspended=True` 53 条，未暂停但 `asleep=True` 3 条。53 条都是用户 `pause_pipeline` 之后进程停在还没建 State 的下一个节点上——`suspended_by` 存的是 pipeline id 而非节点 id，正是整条流程暂停的签名，对应任务在 bk-sops 侧全部"未完成"。

`suspended` / `frozen` 期间进程按设计不再推进，"进程活着但状态不对"这一类判据全部失效，因此对 `missing_state_for_live_process`、`process_alive_but_terminal_state`、`parallel_ack_not_converged`、`schedule_finished_but_process_not_exited` 四条规则统一跳过人工停车的进程。`multiple_sleep_process_for_node` 不受影响（暂停不会产生重复进程），保留原判据。

### 2. 停在 FAILED 节点等人工是设计内行为

引擎 handler 在节点失败时是 `set_state(FAILED)` + `should_sleep=True`，随后 `runtime.sleep(process_id)`，进程 `asleep=True / dead=False` 停在失败节点等人工重试或跳过。这是设计内停车，不再报出；停在 FAILED 但**没睡**的仍然报出。

### 3. `callback_lock_conflict` 排除迟到回调残留与历史 version

25 个命中节点里 24 个是终态 FAILED 节点，其中 23 个当前 version 的 schedule 是 `expired=True`；插件类型 24/25 是 JOB 系（`job_fast_execute_script` 17、`job_execute_task` 6、`all_biz_job_fast_execute_script` 1）。

成因：`Engine.callback()` 只校验"有沉睡进程 + `state.version` 一致 + schedule 未 finished/expired"，**没有校验节点仍在 RUNNING**。节点失败后进程恰好沉睡在该节点上、version 也不变，迟到的 JOB 回调因此能通过全部校验并写入 `CallbackData`；随后调度任务在 `Engine.schedule()` 里撞上 `state.name != RUNNING` 分支，`expire_schedule` 后直接返回，`schedule_times` 不自增（`expire_schedule` 也不会重置它）。于是回调数超过调度次数，判据成立——但节点是 FAILED 等人工，任务没卡。

- 节点已到终态不再报出。这需要把 `states_by_node` 传进该规则，它此前拿不到节点状态。
- 只比对节点**当前 version** 的回调数与调度次数。`Schedule` 按 `(node_id, version)` 唯一，历史 version 的残留按定义挡不住当前 version 的调度。上面 24 个节点一旦被人工重试，跨版本求和会立刻把它们变成新的误判。

### 4. 等待外部回调期间不判为停滞

370 个 `stalled_no_progress` 命中 root 中，348 条是"等外部回调（CALLBACK，调度 0 次）"，20 条是"RUNNING 但没有对应 version 的 Schedule 行"，POLL 型 **0 条**。涉及插件：`remote_plugin` 252、`pause_node` 57、`bk_approve` 26、`job_fast_execute_script` 26、`job_execute_task` 3、`subprocess_plugin` 1。

`runtime.beat()` 只在执行推进循环和 `Engine.schedule()` 内部调用，等回调期间进程两者都不执行，心跳因此冻结在入睡那一刻。而 bk-sops 的主力 JOB 插件（`JobService` 未设 `interval`）以及 `remote_plugin` 都是回调型（`schedule_type()` 的判定是有 `interval` 才 POLL、否则 CALLBACK）。也就是说"心跳静默"是回调型节点的设计必然结果：一个跑 3 小时的 JOB 脚本必然被判静默 3 小时，而 `pause_node` / `bk_approve` 这类等人的节点更是没有任何合理的时长上界（3.24 LTS 也没有 `node_timeout` 能给这个上界）。

因此兜底判据在"节点 RUNNING 且存在未完成未过期的回调型 Schedule"时不再报出。判断只依赖 `Schedule.type`，不需要认识具体插件。反向的两类保持报出并有用例锁定：POLL 型每次轮询都会 beat 且自增 `schedule_times`，静默说明轮询已经停了；回调 schedule 已过期的同样保留。

### 5. 并行网关等收敛不判为卡住，ACK 判据收窄

`ParallelGateway` handler 把网关节点自己置为 FINISHED，然后 `should_sleep=True` 让父进程沉睡等子进程收敛。所以每个还没收敛的并行流程，父进程都是"存活 + 沉睡 + 守在 FINISHED 节点上 + `need_ack > ack_num`"，同时触发 `process_alive_but_terminal_state` 和 `parallel_ack_not_converged`——这正是正在运行的并行流程的正常形态。现网 4251/4251 等 ACK 的进程子进程都仍存活，零可疑。

- `process_alive_but_terminal_state` 在进程等 ACK 时不再报出，收敛是否真的丢了交给 `parallel_ack_not_converged`，不重复报同一个根因。
- `parallel_ack_not_converged` 收窄为"子进程全都不存活却仍未收敛"。子进程还活着时问题在子进程身上、会被它自己的签名抓到。子进程只在按 root 全量收集的快照里，因此按节点/进程收集的快照不再下这个判断，避免"看不到子进程"被误判成"没有子进程"。

### 6. 新增 `schedule_missing_for_running_node`

节点仍 RUNNING、有存活未停车进程守着、却没有对应 version 的 Schedule 行。现网 20 条全部是 `remote_plugin`，`asleep=True` 4 条、`asleep=False` 16 条。

沉睡进程只能由调度或回调唤醒，没有调度记录就是确定性不可唤醒；未沉睡的静默都超过 1 小时，而 `remote_plugin` 的 `execute` 只是发一个带超时的 HTTP 请求，更合理的解释是 celery worker 在 `execute` 途中被杀（OOM / 发布 / 驱逐）。两者都不会再自行往前走，所以都报出，`asleep` 放进证据供定位。

由于后者与"execute 仍在执行"签名重合，该判据只在已确认静默（`stall_seconds` 非空）时生效，并禁用 `resend_schedule` / `replay_callback_data`——此时没有调度和回调可操作。这 20 条此前走兜底 `stalled_no_progress`，现在有专属类型和 critical 定级。

### 7. Layer0 取样池加静默上界

取样池此前没有上界，心跳停在数百天前的历史遗留 root（撤销、库迁移、早期版本残留）长期占满 batch，实测队头静默 1771 天，导致刚静默的 root 永远排不进来——已知卡住的流程静默 54 天，却始终不在候选池里。

- 新增 `PIPELINE_DIAGNOSTICS_SCAN_MAX_SILENT_SECONDS`，默认 7 天，`0` 表示不设上界
- 排序由"最久静默优先"改为"最近静默优先"，保证新出现的停滞能被及时立案
- 上界通过 `last_heartbeat >= floor` 在分组前按行过滤（该列本身有索引），语义与分组后判上界等价
- `scan_stuck_cases` 新增 `--max-silent`，窗口内的历史积压交给一次性回扫，不占用周期任务名额

## 测试

新增 22 个用例，覆盖每一处收窄的正反两面（该压掉的压掉、该保留的保留）。

```
manage.py test pipeline.contrib.diagnostics.tests   -> Ran 89, 87 passed
pytest pipeline/contrib/diagnostics/tests           -> 95 passed, 2 failed
```

两个 runner 里失败的都是 `test_views` 的 `TemplateDoesNotExist`，在未改动的 3.24.14 上同样出现（本地测试工程未把诊断 app 注册进 `INSTALLED_APPS`，模板目录不在 loader 路径上），与本 PR 无关。`flake8 pipeline/contrib/diagnostics/` 无告警。

## 影响面

只影响 `pipeline.contrib.diagnostics` 的判据与取样，不触碰引擎执行链路。按现网数据估算，看板噪音从约 4700 条降到个位数到 20 条量级，同时让真正的新增停滞能进入取样池。

## 后续（不在本 PR）

- `Engine.callback()` 不校验节点是否仍在 RUNNING，迟到回调被写入后又被隐式丢弃，调用方拿到的是成功返回。这是引擎行为本身的问题，改动涉及回调语义和调用方预期，需单独评估。
- `close_stale_cases` 每轮遍历所有 open 案例且逐条查询，案例量大时是瓶颈，开启周期扫描前需要改成批量。
- 回调型节点"等多久算异常"引擎侧给不出上界，需由上层按插件或节点配置，并配合外部对账（JOB 节点可用 `ExecutionData.outputs` 里的 `job_instance_id` 反查真实状态）。

> 注：版本号 bump 到 3.24.15 的 commit 位于中间，分支 tip 才是完整的 3.24.15。