### PR TITLE
fix(diagnostics): 兜底判据也排除人工停车（3.24.16）

### DIFF
--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "3.24.15"
+__version__ = "3.24.16"

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
@@ -52,18 +52,29 @@ def _all_live_processes_parked(snapshot, states_by_node):
     """整条流程的存活进程都停在人工停车点（用户暂停 / 节点失败等重试）。
 
     停车期间不推进是设计内行为，心跳必然停摆，兜底判据不能把它当成停滞。
+
+    等 ACK 收敛的父进程在这里算中性：它自己没有停车，但也不代表流程还在推进——
+    能不能往下走完全取决于子进程，而子进程会各自被判定。典型形态是并行网关下几个分支
+    失败停车，父进程因此永远收不齐 ACK，整条流程实际上是在等人工处理那几个失败分支。
+    子进程若真的卡了（RUNNING 无调度）或全死却未收敛，都有各自的判据接住，不会被这里放过。
     """
     live = [process for process in snapshot.processes if not process.dead]
     if not live:
         return False
+    parked_seen = False
     for process in live:
+        if _waiting_ack_convergence(process):
+            continue
         if _parked_by_user(process):
+            parked_seen = True
             continue
         state = states_by_node.get(process.current_node_id)
         if state is not None and _parked_at_failed_node(process, state):
+            parked_seen = True
             continue
         return False
-    return True
+    # 全是等 ACK 的父进程、一个停车的都没有时不算停车，交回兜底判断
+    return parked_seen
 
 
 def _waiting_external_callback(snapshot, states_by_node, schedules_by_node):

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/rules.py
@@ -48,6 +48,24 @@ def _has_full_process_view(snapshot):
     return not snapshot.node_id and snapshot.process_id is None
 
 
+def _all_live_processes_parked(snapshot, states_by_node):
+    """整条流程的存活进程都停在人工停车点（用户暂停 / 节点失败等重试）。
+
+    停车期间不推进是设计内行为，心跳必然停摆，兜底判据不能把它当成停滞。
+    """
+    live = [process for process in snapshot.processes if not process.dead]
+    if not live:
+        return False
+    for process in live:
+        if _parked_by_user(process):
+            continue
+        state = states_by_node.get(process.current_node_id)
+        if state is not None and _parked_at_failed_node(process, state):
+            continue
+        return False
+    return True
+
+
 def _waiting_external_callback(snapshot, states_by_node, schedules_by_node):
     """引擎正沉睡等待外部回调。
 
@@ -415,6 +433,7 @@ def diagnose_snapshot(snapshot, stall_seconds=None):
         not hits
         and stall_seconds is not None
         and not _waiting_external_callback(snapshot, states_by_node, schedules_by_node)
+        and not _all_live_processes_parked(snapshot, states_by_node)
     ):
         hits = [_stalled_no_progress_hit(snapshot, stall_seconds)]
 

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules_stall.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules_stall.py
@@ -102,6 +102,53 @@ def test_running_node_without_schedule_gets_dedicated_hit():
     assert hits[0].evidence["stall_seconds"] == 7200
 
 
+def _parked_snapshot(suspended=False, frozen=False, state_name=engine_states.RUNNING, asleep=True, node="n1"):
+    """停车中的流程：用户暂停，或节点失败后沉睡等人工重试。"""
+    process = types.SimpleNamespace(
+        id=1,
+        current_node_id=node,
+        dead=False,
+        asleep=asleep,
+        need_ack=-1,
+        ack_num=0,
+        suspended=suspended,
+        frozen=frozen,
+    )
+    state = types.SimpleNamespace(id=1, node_id=node, name=state_name, version="v1")
+    return RuntimeSnapshot(
+        root_pipeline_id="root-1",
+        node_id="",
+        process_id=None,
+        processes=[process],
+        states=[state],
+        schedules=[],
+        callback_data=[],
+    )
+
+
+def test_no_fallback_when_pipeline_suspended_by_user():
+    """用户暂停期间心跳必然停摆，兜底判据也不能把它当成停滞。"""
+    assert diagnose_snapshot(_parked_snapshot(suspended=True), stall_seconds=7200) == []
+
+
+def test_no_fallback_when_process_frozen():
+    assert diagnose_snapshot(_parked_snapshot(frozen=True), stall_seconds=7200) == []
+
+
+def test_no_fallback_when_parked_at_failed_node():
+    """节点失败后沉睡等人工重试或跳过，是设计内停车。"""
+    snapshot = _parked_snapshot(state_name=engine_states.FAILED)
+    assert diagnose_snapshot(snapshot, stall_seconds=7200) == []
+
+
+def test_failed_node_process_not_asleep_still_reported():
+    """停在 FAILED 却没睡不是正常停车形态；新增的停车豁免不能把它一起放过。"""
+    snapshot = _parked_snapshot(state_name=engine_states.FAILED, asleep=False)
+    assert [hit.type for hit in diagnose_snapshot(snapshot, stall_seconds=7200)] == [
+        "process_alive_but_terminal_state"
+    ]
+
+
 def test_fallback_stalled_hit_when_no_specific_rule():
     hits = diagnose_snapshot(_empty_snapshot(), stall_seconds=3600)
     assert len(hits) == 1

--- a/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules_stall.py
+++ b/runtime/bamboo-pipeline/pipeline/contrib/diagnostics/tests/test_rules_stall.py
@@ -149,6 +149,90 @@ def test_failed_node_process_not_asleep_still_reported():
     ]
 
 
+def _gateway_with_failed_branches_snapshot(live_children_failed=2, dead_children=2, ack_num=2, need_ack=4):
+    """现网 task 138970299 的形状：并行网关 4 个分支，2 个完成并 ACK，2 个失败停车。
+
+    父进程停在自己那个 FINISHED 的网关节点上等 ACK 收敛，永远收不齐——因为那两个分支
+    在等人工重试或跳过。整条流程是在等人，不是引擎推不动。
+    """
+    processes = [
+        types.SimpleNamespace(
+            id=1,
+            parent_id=-1,
+            current_node_id="gateway",
+            dead=False,
+            asleep=True,
+            need_ack=need_ack,
+            ack_num=ack_num,
+            suspended=False,
+            frozen=False,
+        )
+    ]
+    states = [types.SimpleNamespace(id=1, node_id="gateway", name=engine_states.FINISHED, version="v1")]
+    for index in range(live_children_failed):
+        node = "failed-%d" % index
+        processes.append(
+            types.SimpleNamespace(
+                id=10 + index,
+                parent_id=1,
+                current_node_id=node,
+                dead=False,
+                asleep=True,
+                need_ack=-1,
+                ack_num=0,
+                suspended=False,
+                frozen=False,
+            )
+        )
+        states.append(
+            types.SimpleNamespace(id=10 + index, node_id=node, name=engine_states.FAILED, version="v1")
+        )
+    for index in range(dead_children):
+        processes.append(
+            types.SimpleNamespace(
+                id=20 + index,
+                parent_id=1,
+                current_node_id="done-%d" % index,
+                dead=True,
+                asleep=False,
+                need_ack=-1,
+                ack_num=0,
+                suspended=False,
+                frozen=False,
+            )
+        )
+    return RuntimeSnapshot(
+        root_pipeline_id="root-1",
+        node_id="",
+        process_id=None,
+        processes=processes,
+        states=states,
+        schedules=[],
+        callback_data=[],
+    )
+
+
+def test_no_fallback_when_gateway_waits_for_failed_parked_branches():
+    """等 ACK 的父进程不算"还在推进"：分支都失败停车时整条流程是在等人工。"""
+    snapshot = _gateway_with_failed_branches_snapshot()
+    assert diagnose_snapshot(snapshot, stall_seconds=4849166) == []
+
+
+def test_fallback_hit_when_gateway_branch_is_genuinely_stuck():
+    """分支不是失败停车而是 RUNNING 无调度时，要由专属判据报出，不能被停车豁免吞掉。"""
+    snapshot = _gateway_with_failed_branches_snapshot(live_children_failed=1)
+    snapshot.states[1].name = engine_states.RUNNING
+    hits = diagnose_snapshot(snapshot, stall_seconds=4849166)
+    assert [hit.type for hit in hits] == ["schedule_missing_for_running_node"]
+
+
+def test_fallback_hit_when_only_ack_waiting_parent_alive():
+    """只剩等 ACK 的父进程、子进程全死：由 ACK 判据报出，不会被当成停车。"""
+    snapshot = _gateway_with_failed_branches_snapshot(live_children_failed=0, dead_children=2)
+    hits = diagnose_snapshot(snapshot, stall_seconds=4849166)
+    assert [hit.type for hit in hits] == ["parallel_ack_not_converged"]
+
+
 def test_fallback_stalled_hit_when_no_specific_rule():
     hits = diagnose_snapshot(_empty_snapshot(), stall_seconds=3600)
     assert len(hits) == 1

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "3.24.15"
+version = "3.24.16"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"


### PR DESCRIPTION
## 背景

3.24.15 上线后在现网按样本逐类核实，六类降噪都生效，但发现停车豁免只加在了六条具体判据上，**漏了兜底的 `stalled_no_progress`**。

结果是人工暂停和失败等重试的流程不再命中原来的具体类型，却被兜底顶上来，案例只是换了个名字：

| 样本 | 3.24.15 实测命中 | 期望 |
| --- | --- | --- |
| 人工暂停（`suspended=True`） | `['stalled_no_progress']` | 无 |
| 失败等重试（FAILED + `asleep`） | `['stalled_no_progress']` | 无 |
| 等外部回调 | 无 | 无（已正确） |

停车期间进程按设计不推进，心跳必然停摆，这属于"引擎按设计停在原地"而不是"引擎推不动了"，兜底同样不该报。而且用户把流程暂停两天完全落在默认取样窗口（1 小时 ~ 7 天）内，所以这条漏洞在正常使用下就会稳定产生噪音，不是只影响历史数据。

## 改动

兜底判据在"整条流程的存活进程都停在人工停车点（用户暂停 / 节点失败等重试）"时不再报出。

要求**全部**存活进程都停车，只要还有一个进程在正常推进就仍然报出——流程局部暂停不应该让整条流程失去诊断。

停在 FAILED 却没睡的仍然报出（由 `process_alive_but_terminal_state` 接住），有用例锁定新增的豁免不会把这个真信号一起放过。

## 顺带确认 3.24.15 的效果

同一轮核实里最关键的一条：已知真卡住的流程（静默 55.8 天）在 3.24.15 下仍被检出，接住它的是新判据 `schedule_missing_for_running_node`。

这条流程原本由 `process_alive_but_terminal_state` 和 `parallel_ack_not_converged` 报出，而这两条正是 3.24.15 收窄掉的（它的父进程等 ACK 收敛且子进程存活，与 4251 条噪音同形）。它能被接住是因为新判据没有以 `asleep=True` 为前提——现网 20 条里 16 条是 `asleep=False`，这条就在其中。若当初按 `asleep` 收窄，它会变成零命中。

## 测试

新增 4 个用例覆盖暂停 / 冻结 / 失败停车，以及"停在 FAILED 但没睡仍要报"的反向用例。

```
pytest pipeline/contrib/diagnostics/tests  -> 99 passed, 2 failed
manage.py test pipeline.contrib.diagnostics.tests -> Ran 89
```

失败的 2 个是 `test_views` 的 `TemplateDoesNotExist`，在未改动的基线上同样出现（本地测试工程未把诊断 app 注册进 `INSTALLED_APPS`），与本 PR 无关。`flake8` 无告警。

> 注：CI 的 `manage.py test pipeline.tests` 不含 `pipeline/contrib/diagnostics/tests`，所以这些用例目前不在 CI 覆盖范围内，需另开 PR 补（同时要修掉上面两个模板报错）。

Made with [Cursor](https://cursor.com)