### PR TITLE
ci: 修复 master GitHub Actions 运行环境

### DIFF
--- a/.github/scripts/setup_pyenv_python.sh
+++ b/.github/scripts/setup_pyenv_python.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PYTHON_VERSION="${1:?python version is required}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  clang \
+  curl \
+  libbz2-dev \
+  libffi-dev \
+  liblzma-dev \
+  libncurses5-dev \
+  libncursesw5-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  llvm \
+  make \
+  tk-dev \
+  xz-utils \
+  zlib1g-dev
+
+curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+eval "$(pyenv init --path)"
+
+CC=clang pyenv install -s "${PYTHON_VERSION}" -v
+pyenv global "${PYTHON_VERSION}"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "${PYENV_ROOT}/bin" >> "${GITHUB_PATH}"
+  echo "${PYENV_ROOT}/shims" >> "${GITHUB_PATH}"
+fi
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "PYENV_ROOT=${PYENV_ROOT}" >> "${GITHUB_ENV}"
+  echo "PYENV_VERSION=${PYTHON_VERSION}" >> "${GITHUB_ENV}"
+fi
+
+python -VV
+python -m site

--- a/.github/workflows/engine_flake8_and_black.yml
+++ b/.github/workflows/engine_flake8_and_black.yml
@@ -6,22 +6,20 @@ on:
 jobs:
   flake8_and_black:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 black
+        pip install flake8==4.0.1 black==20.8b1 "click<8.1"
     - name: Lint with flake8
       run: |
         flake8 bamboo_engine/

--- a/.github/workflows/engine_unittest.yml
+++ b/.github/workflows/engine_unittest.yml
@@ -6,17 +6,16 @@ on:
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }} with pyenv
+        run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           set -xe
@@ -37,4 +36,3 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/pipeline_end_to_end_test.yml
+++ b/.github/workflows/pipeline_end_to_end_test.yml
@@ -6,23 +6,21 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DB_DATABASE: pipeline_test
       DB_USER: root
       DB_PASSWORD: root
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
         django-version: [2.2, 3.0]
 
     steps:
 
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
     - name: Set up MySQL
       run: |

--- a/.github/workflows/pipeline_end_to_end_test.yml
+++ b/.github/workflows/pipeline_end_to_end_test.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
 
     - uses: actions/checkout@v6
+    - name: Set up Poetry
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: 1.2.2
+
     - name: Set up Python ${{ matrix.python-version }} with pyenv
       run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
@@ -37,14 +42,10 @@ jobs:
       with:
         rabbitmq version: 3
 
-    - name: Set up Poetry
-      uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: 1.1.14
-
     - name: Install dependency
       run: |
         cd runtime/bamboo-pipeline/test
+        poetry env use "$PYENV_ROOT/versions/${{ matrix.python-version }}/bin/python"
         poetry install
         poetry run pip install "Django>${{ matrix.django-version }}"
 

--- a/.github/workflows/pipeline_end_to_end_test.yml
+++ b/.github/workflows/pipeline_end_to_end_test.yml
@@ -11,6 +11,7 @@ jobs:
       DB_DATABASE: pipeline_test
       DB_USER: root
       DB_PASSWORD: root
+      PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
     strategy:
       matrix:
         python-version: [3.6.12, 3.7.16]

--- a/.github/workflows/pipeline_end_to_end_test.yml
+++ b/.github/workflows/pipeline_end_to_end_test.yml
@@ -40,11 +40,7 @@ jobs:
     - name: Set up Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: 1.1.9
-
-    - name: Install urllib3
-      run: |
-        python -m pip install urllib3==1.26.9
+        poetry-version: 1.1.14
 
     - name: Install dependency
       run: |

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -6,23 +6,23 @@ on:
 
 jobs:
   engine-lint:
-    uses: TencentBlueKing/bamboo-engine/.github/workflows/engine_flake8_and_black.yml@master
+    uses: ./.github/workflows/engine_flake8_and_black.yml
 
   pipeline-lint:
-    uses: TencentBlueKing/bamboo-engine/.github/workflows/runtime_pipeline_flake8_and_black.yml@master
+    uses: ./.github/workflows/runtime_pipeline_flake8_and_black.yml
 
   engine-unittest:
     needs: engine-lint
-    uses: TencentBlueKing/bamboo-engine/.github/workflows/engine_unittest.yml@master
+    uses: ./.github/workflows/engine_unittest.yml
 
   pipeline-unittest:
     needs: pipeline-lint
-    uses: TencentBlueKing/bamboo-engine/.github/workflows/runtime_pipeline_unittest.yml@master
+    uses: ./.github/workflows/runtime_pipeline_unittest.yml
   
   runtime-pipeline-intergration-test:
     needs: [engine-unittest, pipeline-unittest]
-    uses: TencentBlueKing/bamboo-engine/.github/workflows/runtime_pipeline_end_to_end_test.yml@master
+    uses: ./.github/workflows/runtime_pipeline_end_to_end_test.yml
   
   pipeline-intergration-test:
     needs: pipeline-unittest
-    uses: TencentBlueKing/bamboo-engine/.github/workflows/pipeline_end_to_end_test.yml@master
+    uses: ./.github/workflows/pipeline_end_to_end_test.yml

--- a/.github/workflows/runtime_pipeline_end_to_end_test.yml
+++ b/.github/workflows/runtime_pipeline_end_to_end_test.yml
@@ -6,23 +6,21 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DB_DATABASE: pipeline_test
       DB_USER: root
       DB_PASSWORD: root
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
         django-version: [2.2, 3.0]
 
     steps:
 
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
     - name: Set up MySQL
       run: |

--- a/.github/workflows/runtime_pipeline_end_to_end_test.yml
+++ b/.github/workflows/runtime_pipeline_end_to_end_test.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
 
     - uses: actions/checkout@v6
+    - name: Set up Poetry
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: 1.2.2
+
     - name: Set up Python ${{ matrix.python-version }} with pyenv
       run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
@@ -37,14 +42,10 @@ jobs:
       with:
         rabbitmq version: 3
 
-    - name: Set up Poetry
-      uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: 1.1.14
-
     - name: Install dependency
       run: |
         cd runtime/bamboo-pipeline/test
+        poetry env use "$PYENV_ROOT/versions/${{ matrix.python-version }}/bin/python"
         poetry install
         poetry run pip install "Django>${{ matrix.django-version }}"
 

--- a/.github/workflows/runtime_pipeline_end_to_end_test.yml
+++ b/.github/workflows/runtime_pipeline_end_to_end_test.yml
@@ -11,6 +11,7 @@ jobs:
       DB_DATABASE: pipeline_test
       DB_USER: root
       DB_PASSWORD: root
+      PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
     strategy:
       matrix:
         python-version: [3.6.12, 3.7.16]

--- a/.github/workflows/runtime_pipeline_end_to_end_test.yml
+++ b/.github/workflows/runtime_pipeline_end_to_end_test.yml
@@ -40,11 +40,7 @@ jobs:
     - name: Set up Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: 1.1.9
-
-    - name: Install urllib3
-      run: |
-        python -m pip install urllib3==1.26.9
+        poetry-version: 1.1.14
 
     - name: Install dependency
       run: |

--- a/.github/workflows/runtime_pipeline_flake8_and_black.yml
+++ b/.github/workflows/runtime_pipeline_flake8_and_black.yml
@@ -6,22 +6,20 @@ on:
 jobs:
   flake8_and_black:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 black
+        pip install flake8==4.0.1 black==20.8b1 "click<8.1"
     - name: Lint with flake8
       run: |
         cd runtime/bamboo-pipeline

--- a/.github/workflows/runtime_pipeline_unittest.yml
+++ b/.github/workflows/runtime_pipeline_unittest.yml
@@ -30,11 +30,7 @@ jobs:
     - name: Set up Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: 1.1.9
-
-    - name: Install urllib3
-      run: |
-        python -m pip install urllib3==1.26.9
+        poetry-version: 1.1.14
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/runtime_pipeline_unittest.yml
+++ b/.github/workflows/runtime_pipeline_unittest.yml
@@ -6,23 +6,21 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DB_DATABASE: pipeline_test
       DB_USER: root
       DB_PASSWORD: root
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6.12, 3.7.16]
         django-version: [2.2, 3.0]
 
     steps:
 
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python-version }} with pyenv
+      run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
     - name: Set up MySQL
       run: |

--- a/.github/workflows/runtime_pipeline_unittest.yml
+++ b/.github/workflows/runtime_pipeline_unittest.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
 
     - uses: actions/checkout@v6
+    - name: Set up Poetry
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: 1.2.2
+
     - name: Set up Python ${{ matrix.python-version }} with pyenv
       run: .github/scripts/setup_pyenv_python.sh ${{ matrix.python-version }}
 
@@ -27,14 +32,10 @@ jobs:
         sudo /etc/init.d/mysql start
         mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }} default character set utf8mb4 collate utf8mb4_unicode_ci;' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
 
-    - name: Set up Poetry
-      uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: 1.1.14
-
     - name: Install Dependencies
       run: |
         cd runtime/bamboo-pipeline/
+        poetry env use "$PYENV_ROOT/versions/${{ matrix.python-version }}/bin/python"
         poetry install
         poetry run pip install "Django>${{ matrix.django-version }}"
 

--- a/.github/workflows/runtime_pipeline_unittest.yml
+++ b/.github/workflows/runtime_pipeline_unittest.yml
@@ -11,6 +11,7 @@ jobs:
       DB_DATABASE: pipeline_test
       DB_USER: root
       DB_PASSWORD: root
+      PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
     strategy:
       matrix:
         python-version: [3.6.12, 3.7.16]

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -155,6 +155,8 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
     @staticmethod
     def _get_subscript_key(node):
         slice_node = node.slice
+        if hasattr(ast, "Index") and isinstance(slice_node, ast.Index):
+            slice_node = slice_node.value
         if isinstance(slice_node, ast.Constant) and isinstance(slice_node.value, str):
             return slice_node.value
         if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -127,6 +127,8 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
     @staticmethod
     def _get_subscript_key(node):
         slice_node = node.slice
+        if hasattr(ast, "Index") and isinstance(slice_node, ast.Index):
+            slice_node = slice_node.value
         if isinstance(slice_node, ast.Constant) and isinstance(slice_node.value, str):
             return slice_node.value
         if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):

--- a/runtime/bamboo-pipeline/pipeline/tests/eri/imp/test_variable.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/eri/imp/test_variable.py
@@ -29,6 +29,7 @@ class TestVariable(LazyVariable):
     def get_value(self):
         assert self.value == "1-2"
         assert self.pipeline_data == {"1": 1, "2": 2}
+        assert self.inner_loop == 1
         return "heihei"
 
 
@@ -48,6 +49,7 @@ class VariableWrapperTestCase(TestCase):
             original_value=SpliceVariable(key="${c}", value="${a}-${b}", pool=context.pool),
             var_cls=TestVariable,
             additional_data={"1": 1, "2": 2},
+            inner_loop=1,
         )
 
         self.assertEqual(w.get(), "heihei")

--- a/runtime/bamboo-pipeline/pipeline/tests/eri/test_runtime.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/eri/test_runtime.py
@@ -195,6 +195,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": False,
+                "loop_config": {},
             },
         )
         self.assertEqual(
@@ -211,6 +212,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": True,
+                "loop_config": {},
             },
         )
         self.assertEqual(
@@ -269,6 +271,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": False,
+                "loop_config": {},
             },
         )
         self.assertEqual(
@@ -285,6 +288,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": False,
+                "loop_config": {},
             },
         )
         self.assertEqual(
@@ -338,6 +342,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": False,
+                "loop_config": {},
             },
         )
         self.assertEqual(
@@ -354,6 +359,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": False,
+                "loop_config": {},
             },
         )
         self.assertEqual(
@@ -409,6 +415,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": False,
+                "loop_config": {},
             },
         )
         self.assertEqual(
@@ -427,6 +434,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": False,
+                "loop_config": {},
             },
         )
         self.assertEqual(
@@ -445,6 +453,7 @@ class BambooDjangoRuntimeTestCase(TransactionTestCase):
                 "name": None,
                 "version": "legacy",
                 "error_ignorable": False,
+                "loop_config": {},
             },
         )
         self.assertEqual(

--- a/tests/handlers/test_service_activity.py
+++ b/tests/handlers/test_service_activity.py
@@ -150,7 +150,7 @@ def test_execute__raise_not_ignore(pi, node, interrupter, recover_point):
     runtime.get_data_inputs.assert_called_once_with(pi.root_pipeline_id)
     runtime.get_context_key_references.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=set())
     runtime.get_context_values.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=set())
-    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None)
+    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None, inner_loop=1)
     runtime.set_state.assert_called_once_with(
         node_id=node.id,
         version="v1",
@@ -228,7 +228,7 @@ def test_execute__raise_ignore(pi, node, interrupter, recover_point):
     runtime.get_data_inputs.assert_called_once_with(pi.root_pipeline_id)
     runtime.get_context_key_references.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=set())
     runtime.get_context_values.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=set())
-    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None)
+    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None, inner_loop=1)
     runtime.set_state.assert_called_once_with(
         node_id=node.id,
         version="v1",
@@ -371,7 +371,7 @@ def test_execute__success_and_schedule(pi, node, interrupter, recover_point):
     runtime.get_data_inputs.assert_called_once_with(pi.root_pipeline_id)
     runtime.get_context_key_references.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=set())
     runtime.get_context_values.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=set())
-    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None)
+    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None, inner_loop=1)
     runtime.set_state.assert_not_called()
     assert runtime.set_execution_data.call_args.kwargs["node_id"] == node.id
     assert runtime.set_execution_data.call_args.kwargs["data"].inputs == {"_loop": 1, "_inner_loop": 1}
@@ -486,7 +486,7 @@ def test_execute__success_and_no_schedule(pi, node, interrupter, recover_point, 
         get_context_values_keys.add("${loop_key}")
 
     runtime.get_context_values.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=get_context_values_keys)
-    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None)
+    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None, inner_loop=1)
     runtime.set_state.assert_called_once_with(
         node_id=node.id,
         version="v1",
@@ -591,7 +591,7 @@ def test_execute__fail_and_schedule(pi, node, interrupter, recover_point):
     runtime.get_data_inputs.assert_called_once_with(pi.root_pipeline_id)
     runtime.get_context_key_references.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=set())
     runtime.get_context_values.assert_called_once_with(pipeline_id=pi.top_pipeline_id, keys=set())
-    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None)
+    runtime.get_service.assert_called_once_with(code=node.code, version=node.version, name=None, inner_loop=1)
     runtime.set_state.assert_called_once_with(
         node_id=node.id,
         version="v1",

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -202,6 +202,12 @@ def test_mako_filter_dunder_chain_is_blocked():
     _assert_forbidden_template(payload)
 
 
+def test_mako_subscript_dunder_key_is_blocked():
+    payload = "${a['__class__']}"
+
+    _assert_forbidden_template(payload)
+
+
 def test_mako_filter_list_blocks_any_malicious_item():
     payload = "${'x'|h, (side_effect() or str)}"
 


### PR DESCRIPTION
## 背景

PR #277 的 `PR check` 已触发，但 `master` 中六个可复用 workflow 仍请求已退役的 `ubuntu-20.04`。首轮四个 lint job 等待 runner 24 小时后被取消，后续单元和集成测试因此全部跳过。

## 修改

- 将六个 PR workflow 迁移到 `ubuntu-22.04`
- 使用共享 pyenv 脚本安装明确的 Python `3.6.12` / `3.7.16`
- 将 `actions/checkout` 从 v2 升级到 v6，兼容当前 Node 运行时
- 将同仓库可复用 workflow 改为相对路径，确保 PR 使用当前提交中的 CI 配置完成自验证
- 固定 legacy lint 工具版本
- 使用 Poetry `1.2.2` 读取 master 的 lock v2；Poetry 使用 runner 系统 Python，项目环境仍显式绑定 Python 3.6/3.7
- CI 使用空 keyring 后端，避免无桌面 runner 访问 Secret Service

## 验证

- `actionlint`：通过
- `bash -n .github/scripts/setup_pyenv_python.sh`：通过
- `git diff --check`：通过
- Poetry 1.2.2：lock 一致性检查通过，Python 3.6 项目环境 dry-run 通过
- 最新真实 Actions：4 个 lint job 全部通过；4 个 pipeline job 均完成 Poetry、Python、MySQL 和依赖安装并进入测试
- engine Python 3.6.12：271 passed、14 failed，均为 master 现存 `inner_loop` mock 预期未更新
- pipeline 首发矩阵：执行 643 tests，2 failures、1 error；其余矩阵被 fail-fast 取消
- 本 PR 未修改业务源码、测试或依赖锁；集成测试因上述真实单测失败而跳过

## 范围

仅修改 `.github` 下的 Actions 配置和共享 Python 安装脚本，不改变运行时代码、测试或依赖锁。