### PR TITLE
minor: update pipeline version to 3.29.10

### DIFF
--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "3.29.9"
+__version__ = "3.29.10"

--- a/runtime/bamboo-pipeline/poetry.lock
+++ b/runtime/bamboo-pipeline/poetry.lock
@@ -86,13 +86,13 @@ tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy
 
 [[package]]
 name = "bamboo-engine"
-version = "2.11.3"
+version = "2.11.4"
 description = "Bamboo-engine is a general-purpose workflow engine"
 optional = false
 python-versions = "<4,>=3.6"
 files = [
-    {file = "bamboo_engine-2.11.3-py3-none-any.whl", hash = "sha256:7ee240a801bb866acd3788fd0b73137c3472b9e4e1f7cd4499f3dffd7f84b796"},
-    {file = "bamboo_engine-2.11.3.tar.gz", hash = "sha256:9b10b85a64c04ec4a03eb4f443c705e855a31b75ac9c9061e892baa7715c1298"},
+    {file = "bamboo_engine-2.11.4-py3-none-any.whl", hash = "sha256:78044f3274aea784090fc27e1a45d4bc6c06b715885cfdea9d1ef8d237300e19"},
+    {file = "bamboo_engine-2.11.4.tar.gz", hash = "sha256:31d1848ab9c660bd55a11f661acbb22a2fd01d4a53b8aff3544a450a0f6fb4bc"},
 ]
 
 [package.dependencies]
@@ -1320,4 +1320,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.6, < 4"
-content-hash = "7330f0747c3872874a90caa40db25232986ee9400a31857cbaf9a17064a3fbd7"
+content-hash = "a393cdc1100d7ddab5ff275c34a84b5e80829e217ebc2704c3b45bff826862b4"

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "3.29.9"
+version = "3.29.10"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["homholueng <homholueng@gmail.com>"]
 license = "MIT"
@@ -16,7 +16,7 @@ requests = "^2.22"
 django-celery-beat = "^2.1"
 Mako = "^1.1.4"
 pytz = ">=2019.3"
-bamboo-engine = "^2.11.3"
+bamboo-engine = "^2.11.4"
 jsonschema = "^2.5.1"
 ujson = "^4"
 pyparsing = "^2.2"


### PR DESCRIPTION
## 变更说明

- 将 `bamboo-pipeline` 版本从 `3.29.9` 更新到 `3.29.10`
- 将 `bamboo-engine` 依赖从 `^2.11.3` 更新到已发布的 `^2.11.4`
- 使用 Poetry 1.5.1、Python 3.7.16 执行 `poetry lock --no-update`，lock 仅更新 engine 版本、包哈希与内容哈希
- 用于发布已合入 master 的 SubCanvas 能力（#277）

## 验证

- `poetry check`
- 依赖解析：`bamboo-engine 2.11.4`、`bamboo-pipeline 3.29.10`
- `poetry build -vvv`
- wheel 元数据：`Version: 3.29.10`、`bamboo-engine (>=2.11.4,<3.0.0)`
- 本地 SQLite 单测：643 个用例中 642 通过；1 个并发用例因 SQLite `database table is locked` 失败，仓库官方 CI 使用 MySQL，以 PR 矩阵结果为准

## 发布顺序

`bamboo-engine 2.11.4` 已完成 Actions 发布并在 PyPI 提供 wheel 与 sdist。本 PR 合入后创建 `bamboo-pipeline-v3.29.10` 标签发布 pipeline。