### PR TITLE
fix(mako): 按攻击原语收紧 enforce，避免误伤 _module 与光杆 caller

### DIFF
--- a/bamboo_engine/__version__.py
+++ b/bamboo_engine/__version__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-__version__ = "2.11.4"
+__version__ = "2.11.5"

--- a/bamboo_engine/template/sandbox.py
+++ b/bamboo_engine/template/sandbox.py
@@ -35,14 +35,30 @@ class ModuleObject:
         setattr(self, sub_paths[0], ModuleObject(sub_paths[1:], module))
 
 
+def resolve_import_object(mod_path):
+    try:
+        return importlib.import_module(mod_path)
+    except ImportError:
+        parts = mod_path.split(".")
+        obj = importlib.import_module(parts[0])
+        for part in parts[1:]:
+            obj = getattr(obj, part)
+        return obj
+
+
 def _import_modules(sandbox: dict, modules: Dict[str, str]):
-    for mod_path, alias in modules.items():
-        mod = importlib.import_module(mod_path)
+    items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
+    for mod_path, alias in items:
+        obj = resolve_import_object(mod_path)
         sub_paths = alias.split(".")
         if len(sub_paths) == 1:
-            sandbox[alias] = mod
-        else:
-            sandbox[sub_paths[0]] = ModuleObject(sub_paths[1:], mod)
+            sandbox[alias] = obj
+            continue
+        root = sub_paths[0]
+        existing = sandbox.get(root)
+        if existing is not None and not isinstance(existing, ModuleObject):
+            continue
+        sandbox[root] = ModuleObject(sub_paths[1:], obj)
 
 
 def get() -> dict:

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -305,9 +305,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
       * ``enforce``：抛 :exc:`ForbiddenMakoTemplateException`，由
         :func:`bamboo_engine.utils.mako_utils.checker.check_mako_template_safety` 捕获。
 
-    本 visitor 还显式拦截 :data:`MAKO_RESERVED_NAMESPACES` 中的标识符，
-    无论是否被传入 ``allowed_names`` 都会被拒，避免误把 ``self/context/...`` 加进
-    上下文导致 SSTI 链路被放行。
+    光杆保留名（:data:`MAKO_RESERVED_NAMESPACES`）放行；保留名上的属性链仍拒，
+    避免 ``self.module...`` 一类 SSTI 链路被放行。单下划线 attr 不再一刀切，
+    仅双下划线与 :data:`DANGEROUS_ATTR_NAMES` 在属性节点上拦截。
 
     支持 ``ListComp / SetComp / DictComp / GeneratorExp / Lambda`` 引入的局部
     绑定——这些临时变量会被压入作用域栈，在子树访问完后自动弹出。
@@ -357,23 +357,26 @@ class WhitelistNameVisitor(ast.NodeVisitor):
         if not isinstance(node.ctx, ast.Load):
             return
         if node.id in MAKO_RESERVED_NAMESPACES:
-            self._violate(node.id, "mako reserved namespace")
             return
         if not self._name_allowed(node.id):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
-        # 单下划线 attr 拒绝：堵 ``context._with_template / context._kwargs`` 这类
-        # Python "半私有" 通道（双下划线已经在 ``SingleLineNodeVisitor`` 拦过，这里
-        # 顺手收紧成单下划线，覆盖更广）。
-        if node.attr.startswith("_"):
+        if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return
-        # 危险 attr 名拒绝：堵 ``${os.path.os.popen(...)}`` /
-        # ``${datetime.sys.modules['os'].popen(...)}`` 类反向引用链路。
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
             return
+        kind, root, attrs = resolve_attr_chain(node)
+        if kind == "name" and root in MAKO_RESERVED_NAMESPACES:
+            self._violate(root, "mako reserved namespace attribute")
+            return
+        if kind == "name":
+            reason = import_chain_violation(root, attrs, configured_import_aliases())
+            if reason:
+                self._violate(root, reason)
+                return
         self.generic_visit(node)
 
     def _enter_comprehension(self, node):

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -225,6 +225,45 @@ def _deformat_var_key(key):
     return key
 
 
+def resolve_attr_chain(node):
+    attrs = [node.attr]
+    cur = node.value
+    while isinstance(cur, ast.Attribute):
+        attrs.append(cur.attr)
+        cur = cur.value
+    attrs.reverse()
+    if isinstance(cur, ast.Name):
+        return "name", cur.id, attrs
+    if isinstance(cur, ast.Call):
+        return "call_result", None, attrs
+    return "other", None, attrs
+
+
+def import_chain_violation(root, attrs, aliases):
+    if not root:
+        return None
+    roots = set(alias.split(".", 1)[0] for alias in aliases)
+    if root not in roots:
+        return None
+    best_len = -1
+    for index in range(len(attrs) + 1):
+        candidate = root if index == 0 else "{}.{}".format(root, ".".join(attrs[:index]))
+        if candidate in aliases:
+            best_len = index
+    if best_len < 0:
+        return "import path not configured"
+    if len(attrs[best_len:]) > 1:
+        return "import attr deeper than one level"
+    return None
+
+
+def configured_import_aliases():
+    from bamboo_engine.config import Settings
+
+    modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    return frozenset(alias for alias in modules.values() if alias)
+
+
 def build_allowed_names(context, *, extra=()):
     """根据当前渲染 context 与全局 ``Settings`` 计算白名单的根标识符集合。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-engine"
-version = "2.11.4"
+version = "2.11.5"
 description = "Bamboo-engine is a general-purpose workflow engine"
 authors = ["homholueng <homholueng@gmail.com>"]
 license = "MIT"

--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "3.29.10"
+__version__ = "3.29.11"

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -16,6 +16,11 @@ import re
 
 from mako import parsetree
 
+from bamboo_engine.utils.mako_safety import (
+    configured_import_aliases,
+    import_chain_violation,
+    resolve_attr_chain,
+)
 from pipeline.utils.mako_utils.code_extract import MakoNodeCodeExtractor
 from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
@@ -277,23 +282,30 @@ class WhitelistNameVisitor(ast.NodeVisitor):
                 WhitelistNameVisitor._collect_targets(elt, into)
 
     def visit_Name(self, node):
+        # Store / Del 上下文是赋值/删除目标，由 _enter_* 显式处理，跳过命名检查
         if not isinstance(node.ctx, ast.Load):
             return
         if node.id in MAKO_RESERVED_NAMESPACES:
-            self._violate(node.id, "mako reserved namespace")
             return
         if not self._name_allowed(node.id):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
-        # 与新引擎 ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor.visit_Attribute``
-        # 保持一致：单下划线前缀 + 危险 attr 名一律拒绝，堵反向引用 SSTI 链路。
-        if node.attr.startswith("_"):
+        if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
             return
+        kind, root, attrs = resolve_attr_chain(node)
+        if kind == "name" and root in MAKO_RESERVED_NAMESPACES:
+            self._violate(root, "mako reserved namespace attribute")
+            return
+        if kind == "name":
+            reason = import_chain_violation(root, attrs, configured_import_aliases())
+            if reason:
+                self._violate(root, reason)
+                return
         self.generic_visit(node)
 
     def _enter_comprehension(self, node):

--- a/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
 # mock str return value of Built-in Functions，make str(func) return "func" rather than "<built-in function func>"
 
 import builtins
-import importlib
 
+from bamboo_engine.template.sandbox import resolve_import_object
 from pipeline.conf import default_settings
 
 SANDBOX = {}
@@ -48,13 +48,18 @@ class ModuleObject:
 
 
 def _import_modules(sandbox, modules):
-    for mod_path, alias in modules.items():
-        mod = importlib.import_module(mod_path)
+    items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
+    for mod_path, alias in items:
+        obj = resolve_import_object(mod_path)
         sub_paths = alias.split(".")
         if len(sub_paths) == 1:
-            sandbox[alias] = mod
-        else:
-            sandbox[sub_paths[0]] = ModuleObject(sub_paths[1:], mod)
+            sandbox[alias] = obj
+            continue
+        root = sub_paths[0]
+        existing = sandbox.get(root)
+        if existing is not None and not isinstance(existing, ModuleObject):
+            continue
+        sandbox[root] = ModuleObject(sub_paths[1:], obj)
 
 
 def _mock_builtins():

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -288,16 +288,46 @@ class TestMakoNameWhitelist(TestCase):
         finally:
             self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
 
-    def test_single_underscore_attr_blocked(self):
+    def test_reserved_namespace_attributes_blocked(self):
         self._set_mode("enforce")
         for p in [
             "${context._kwargs}",
             "${context._with_template}",
-            "${obj._secret}",
         ]:
             with self.subTest(payload=p):
-                rendered = expression.ConstantTemplate(p).resolve_data({"obj": object()})
+                rendered = expression.ConstantTemplate(p).resolve_data({})
                 self.assertEqual(rendered, p)
+
+    def test_user_single_underscore_attr_allowed(self):
+        self._set_mode("enforce")
+
+        class Bag(object):
+            def __init__(self):
+                self._module = [{"gamesvr": "1.1.1.1"}]
+
+        rendered = expression.ConstantTemplate("${obj._module[0]['gamesvr']}").resolve_data({"obj": Bag()})
+        self.assertEqual(rendered, "1.1.1.1")
+
+    def test_bare_caller_allowed(self):
+        self._set_mode("enforce")
+        # ConstantTemplate short-circuits a lone ``${caller}`` from context before
+        # the whitelist visitor (same as new-engine Template.render). Use an
+        # expression so visit_Name actually runs. ``parent`` is also reserved;
+        # Mako injects ``caller`` as a frame list, which would stay inert.
+        self.assertEqual(
+            expression.ConstantTemplate("${parent + ''}").resolve_data({"parent": "alice"}),
+            "alice",
+        )
+
+    def test_import_deep_chain_blocked(self):
+        self._set_mode("enforce")
+        original = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {"json": "json"}
+        try:
+            payload = "${json.codecs.builtins.exec('1')}"
+            self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original
 
     def test_business_patterns_still_render(self):
         self._set_mode("enforce")

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "3.29.10"
+version = "3.29.11"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["homholueng <homholueng@gmail.com>"]
 license = "MIT"
@@ -16,7 +16,7 @@ requests = "^2.22"
 django-celery-beat = "^2.1"
 Mako = "^1.1.4"
 pytz = ">=2019.3"
-bamboo-engine = "^2.11.4"
+bamboo-engine = "^2.11.5"
 jsonschema = "^2.5.1"
 ujson = "^4"
 pyparsing = "^2.2"

--- a/tests/template/test_mako_attr_policy.py
+++ b/tests/template/test_mako_attr_policy.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import ast
+
+from bamboo_engine.utils.mako_safety import import_chain_violation, resolve_attr_chain
+
+
+def _attr_node(expr):
+    tree = ast.parse(expr, "<t>", "eval")
+    node = tree.body
+    while isinstance(node, ast.Call):
+        node = node.func
+    assert isinstance(node, ast.Attribute)
+    return node
+
+
+def test_resolve_attr_chain_name_two_levels():
+    kind, root, attrs = resolve_attr_chain(_attr_node("json.codecs.builtins"))
+    assert kind == "name"
+    assert root == "json"
+    assert attrs == ["codecs", "builtins"]
+
+
+def test_resolve_attr_chain_stops_at_call():
+    kind, root, attrs = resolve_attr_chain(_attr_node('datetime.datetime.now().strftime("%Y")'))
+    assert kind == "call_result"
+    assert root is None
+    assert attrs == ["strftime"]
+
+
+def test_import_json_loads_ok():
+    aliases = frozenset(["json", "re", "os.path", "datetime", "datetime.datetime"])
+    assert import_chain_violation("json", ["loads"], aliases) is None
+
+
+def test_import_os_path_join_ok():
+    aliases = frozenset(["os.path", "json"])
+    assert import_chain_violation("os", ["path", "join"], aliases) is None
+
+
+def test_import_os_popen_rejected():
+    aliases = frozenset(["os.path"])
+    reason = import_chain_violation("os", ["popen"], aliases)
+    assert reason is not None
+
+
+def test_import_json_codecs_builtins_rejected():
+    aliases = frozenset(["json"])
+    reason = import_chain_violation("json", ["codecs", "builtins"], aliases)
+    assert reason is not None
+
+
+def test_import_datetime_now_needs_class_alias():
+    aliases = frozenset(["datetime"])
+    assert import_chain_violation("datetime", ["datetime", "now"], aliases) is not None
+    aliases = frozenset(["datetime", "datetime.datetime"])
+    assert import_chain_violation("datetime", ["datetime", "now"], aliases) is None
+
+
+def test_non_import_root_is_ignored():
+    aliases = frozenset(["json"])
+    assert import_chain_violation("resdata", ["_module"], aliases) is None

--- a/tests/template/test_sandbox_import.py
+++ b/tests/template/test_sandbox_import.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import datetime as dt
+
+from bamboo_engine.template.sandbox import ModuleObject, _import_modules, resolve_import_object
+
+
+def test_resolve_import_object_module():
+    import json
+
+    assert resolve_import_object("json") is json
+
+
+def test_resolve_import_object_class_path():
+    assert resolve_import_object("datetime.datetime") is dt.datetime
+
+
+def test_dotted_alias_does_not_clobber_existing_module():
+    sandbox = {}
+    _import_modules(
+        sandbox,
+        {
+            "datetime": "datetime",
+            "datetime.datetime": "datetime.datetime",
+        },
+    )
+    assert sandbox["datetime"] is dt
+    assert sandbox["datetime"].datetime is dt.datetime
+    assert sandbox["datetime"].timedelta is dt.timedelta
+    assert not isinstance(sandbox["datetime"], ModuleObject)
+
+
+def test_os_path_still_uses_module_object():
+    sandbox = {}
+    _import_modules(sandbox, {"os.path": "os.path"})
+    assert isinstance(sandbox["os"], ModuleObject)
+    assert hasattr(sandbox["os"], "path")
+    assert not hasattr(sandbox["os"], "popen")

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -104,6 +104,14 @@ def test_render__with_sandbox():
     Settings.MAKO_SANDBOX_IMPORT_MODULES = {"datetime": "datetime"}
 
     r2 = Template("""${datetime.datetime.now().strftime("%Y")}""").render({})
+    assert r2 == """${datetime.datetime.now().strftime("%Y")}"""
+
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "datetime.datetime": "datetime.datetime",
+    }
+
+    r2 = Template("""${datetime.datetime.now().strftime("%Y")}""").render({})
     year = datetime.datetime.now().strftime("%Y")
     assert r2 == year
 
@@ -143,7 +151,7 @@ def test_mako_attack():
 #
 # 1. ``self / context / local / parent / next / caller / pageargs`` 等 Mako
 #    渲染期注入的保留命名空间（堵 ``self.module.cache.util.os.popen`` SSTI 链路）。
-# 2. attr 链路上的危险字段 / 单下划线 attr，堵 ``${os.path.os.popen(...)}``、
+# 2. 保留名属性链 / 导入前缀外超一级，堵 ``${os.path.os.popen(...)}``、
 #    ``${datetime.sys.modules['os']...}``、``${context._kwargs}`` 这类反向引用。
 # 3. 业务正常用法（字符串方法、``datetime.datetime.now().strftime(...)``、
 #    ``os.path.join`` / 列表推导 / lambda）必须照常渲染。
@@ -289,13 +297,34 @@ def test_mako_whitelist_blocks_dangerous_attr_chain(whitelist_mode, payload):
         "${context._kwargs}",
         "${context._with_template}",
         "${context._data}",
-        "${obj._secret}",
-        "${obj.public._private}",
     ],
 )
-def test_mako_whitelist_blocks_single_underscore_attr(whitelist_mode, payload):
+def test_mako_whitelist_blocks_reserved_namespace_attributes(whitelist_mode, payload):
     whitelist_mode("enforce")
-    rendered = Template({"x": payload}).render({"obj": object()})
+    rendered = Template({"x": payload}).render({})
+    assert rendered["x"] == payload
+
+
+def test_mako_whitelist_allows_user_single_underscore_attr(whitelist_mode):
+    whitelist_mode("enforce")
+
+    class Bag(object):
+        def __init__(self):
+            self._module = [{"gamesvr": "1.1.1.1"}]
+
+    out = Template("${obj._module[0]['gamesvr']}").render({"obj": Bag()})
+    assert out == "1.1.1.1"
+
+
+def test_mako_whitelist_allows_bare_reserved_name(whitelist_mode):
+    whitelist_mode("enforce")
+    assert Template("${caller}").render({"caller": "alice"}) == "alice"
+
+
+def test_mako_whitelist_blocks_self_module_even_if_self_in_context(whitelist_mode):
+    whitelist_mode("enforce")
+    payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+    rendered = Template({"x": payload}).render({"self": "ignored"})
     assert rendered["x"] == payload
 
 
@@ -318,14 +347,31 @@ def test_mako_whitelist_allows_imported_modules(whitelist_mode):
     original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
     Settings.MAKO_SANDBOX_IMPORT_MODULES = {
         "datetime": "datetime",
+        "datetime.datetime": "datetime.datetime",
         "os.path": "os.path",
+        "json": "json",
+        "hashlib": "hashlib",
     }
     try:
-        # os.path.join 仍可用（join 不在 DANGEROUS_ATTR_NAMES）
         assert Template('${os.path.join("a", "b")}').render({}) == "a/b"
-        # datetime.datetime.now().strftime 链路全程合法
         out = Template('${datetime.datetime.now().strftime("%Y")}').render({})
         assert len(out) == 4 and out.isdigit()
+        assert Template("${json.dumps({'a': 1})}").render({})
+        digest = Template("${hashlib.md5(b'x').hexdigest()}").render({})
+        assert len(digest) == 32
+        deep = "${json.codecs.builtins.exec('1')}"
+        assert Template({"x": deep}).render({})["x"] == deep
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+def test_mako_whitelist_datetime_now_requires_configured_class_alias(whitelist_mode):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {"datetime": "datetime"}
+    try:
+        payload = '${datetime.datetime.now().strftime("%Y")}'
+        assert Template({"x": payload}).render({})["x"] == payload
     finally:
         Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
 

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -318,7 +318,7 @@ def test_mako_whitelist_allows_user_single_underscore_attr(whitelist_mode):
 
 def test_mako_whitelist_allows_bare_reserved_name(whitelist_mode):
     whitelist_mode("enforce")
-    assert Template("${caller}").render({"caller": "alice"}) == "alice"
+    assert Template("${parent + ''}").render({"parent": "alice"}) == "alice"
 
 
 def test_mako_whitelist_blocks_self_module_even_if_self_in_context(whitelist_mode):


### PR DESCRIPTION
## 背景

`MAKO_TEMPLATE_NAME_WHITELIST_MODE=enforce` 原先按「名字长什么样」拦截，会误伤开区官方字段 `${resdata._module}`、光杆变量 `${caller}`，同时又拦不住导入模块深爬（`${json.codecs.builtins.exec(...)}`）。SOPS-01 真实 payload 仍必须保持拦截：

```
${self.module.cache.util.os.popen('whoami').read()}
```

## 改动

- 单下划线属性默认合法；`__*` 与 `DANGEROUS_ATTR_NAMES` 仍拦。
- 保留名只放行光杆引用；根是 `self/context/local/parent/caller/...` 再取属性一律拦截。不会因为 context 里有同名变量就放行整链。
- 导入模块按配置 alias 最长前缀 + Call 前只允许再取一个属性；Call 之后的 `.strftime` / `.hexdigest` 本期不禁。
- 新增 `resolve_import_object`：点分路径先 `import_module`，失败再按点 `getattr`，用于绑定 `datetime.datetime` 这类类对象。较短 alias 先绑，已注入的真实模块不会被 `ModuleObject` 覆盖。
- 新引擎 visitor 与 legacy `bamboo-pipeline` visitor / sandbox 对齐。
- 版本：`bamboo-engine` 2.11.4 → **2.11.5**，`bamboo-pipeline` 3.29.10 → **3.29.11**，pipeline 依赖 `bamboo-engine = "^2.11.5"`。

## 兼容性

- 不新增第四档 mode；`off` / `warn` / `enforce` 只表示执行力度。
- 无条件规则未改：未知 filter、`import`、`__` 名、`.format` / `.format_map`。
- 检查器不写死 `_module` / `caller` / `loads` / `strftime` / `datetime`。
- 3.24 LTS 不在本 PR 平行实现第三份 visitor；需要时再 cherry-pick / 打包。

## 验证

- `tests/template/test_mako_attr_policy.py` / `test_sandbox_import.py` / `test_template.py`：70 passed。
- 覆盖 SOPS-01、context 中有 `self` 仍拦截、`os.path.join`、`datetime.datetime.now().strftime`、`hashlib.md5().hexdigest`、`json.codecs.builtins`。

## 发布注意

- 本 PR 必须先于 bk-sops 侧 `datetime.datetime` 别名生效。已发布的 2.11.4 / 3.29.10 **没有** `resolve_import_object`。
- 配套 SaaS PR 会在缺少该符号时跳过别名，避免旧 `import_module` 把进程打挂。


Made with [Cursor](https://cursor.com)