### PR TITLE
fix(mako): 3.24 LTS 按攻击原语收紧 enforce，避免误伤 _module 与光杆 caller

### DIFF
--- a/bamboo_engine/__version__.py
+++ b/bamboo_engine/__version__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-__version__ = "2.6.5"
+__version__ = "2.6.6"

--- a/bamboo_engine/config.py
+++ b/bamboo_engine/config.py
@@ -21,6 +21,7 @@ class Settings:
 
     MAKO_SANDBOX_SHIELD_WORDS = [
         "ascii",
+        "breakpoint",
         "bytearray",
         "bytes",
         "callable",
@@ -33,6 +34,7 @@ class Settings:
         "exec",
         "eval",
         "filter",
+        "format",
         "frozenset",
         "getattr",
         "globals",
@@ -62,5 +64,17 @@ class Settings:
     ]
 
     MAKO_SANDBOX_IMPORT_MODULES = {}
+
+    # 模板根标识符白名单模式：
+    #   "off"     - 关闭白名单（兼容历史行为）
+    #   "warn"    - 仅记录违规日志，不阻断渲染（灰度阶段使用）
+    #   "enforce" - 违规即按当前 deny-list 风格拦截（行为同 ForbiddenMakoTemplateException）
+    # 默认 "enforce"，避免默认安装后继续暴露 Mako 渲染期保留命名空间注入链路。
+    # 如接入方确有兼容性风险，可在自身 settings 中临时切到 "warn" 或 "off"。
+    MAKO_TEMPLATE_NAME_WHITELIST_MODE = "enforce"
+
+    # 在白名单基础上额外允许的根标识符（除 context/导入模块/SAFE_BUILTIN_NAMES 之外）。
+    # 接入方通常用于声明 ``_system``、``_loop`` 这类 Mako 渲染期才注入的特殊对象名。
+    MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset()
 
     RERUN_INDEX_OFFSET = 0

--- a/bamboo_engine/template/sandbox.py
+++ b/bamboo_engine/template/sandbox.py
@@ -17,9 +17,65 @@ specific language governing permissions and limitations under the License.
 
 from typing import List, Dict
 
+import logging
 import importlib
 
 from bamboo_engine.config import Settings
+
+logger = logging.getLogger("root")
+
+
+# 渲染期从模板模块 ``__builtins__`` 中摘除的危险内建。
+#
+# Mako 会把每段模板编译进一个独立 module，其 ``__builtins__`` 默认指向**真实** builtins。
+# 模板里通过 ``(g).gi_frame.f_builtins`` / ``frame.f_globals['__builtins__']`` 等反射链路
+# 拿到的正是这个 module 的 builtins。即便 AST deny-list 漏掉了某条通向 frame 的属性，
+# 只要这里事先把可直接"执行代码 / 读写文件"的原语摘掉，攻击者拿到的 builtins 视图里也
+# 不再有可用武器，是 deny-list 之外的纵深防御（capability allow-list by removal）。
+#
+# 仅摘除"非 ``__`` 前缀、可当作下标 key 直接取用"的执行 / IO 原语：
+# ``f_builtins['eval'](...)`` / ``['exec'](...)`` / ``['open'](...)`` 这类。
+# 刻意**保留** ``__import__``：它是 ``__`` 前缀（下标 / 属性 / 名称三条路径都已被
+# dunder 规则拦死，无法被直接取用），且 CPython 的 C 扩展在渲染期会惰性 import
+# （如 ``datetime.strftime`` 内部 ``import time``），摘掉会误伤正常渲染。
+# 同样保留 ``str/len/range`` 等 Mako codegen 与业务表达式需要的安全内建。
+DANGEROUS_RENDER_BUILTINS = frozenset(
+    {
+        "eval",
+        "exec",
+        "compile",
+        "open",
+        "input",
+        "breakpoint",
+    }
+)
+
+_RESTRICTED_BUILTINS = None
+
+
+def restricted_builtins() -> dict:
+    """返回去除 :data:`DANGEROUS_RENDER_BUILTINS` 后的 builtins 视图（只读、进程内缓存）。"""
+    global _RESTRICTED_BUILTINS
+    if _RESTRICTED_BUILTINS is None:
+        import builtins as _builtins
+
+        safe = {name: getattr(_builtins, name) for name in dir(_builtins)}
+        for name in DANGEROUS_RENDER_BUILTINS:
+            safe.pop(name, None)
+        _RESTRICTED_BUILTINS = safe
+    return _RESTRICTED_BUILTINS
+
+
+def harden_template_builtins(mako_template) -> None:
+    """把编译后模板模块的 ``__builtins__`` 换成去除危险原语的视图。
+
+    需在任何一次 render 创建 frame 之前调用。Mako 各版本内部结构略有差异，任何异常都不应
+    影响正常渲染，因此整体 try/except 兜底。
+    """
+    try:
+        mako_template.module.__builtins__ = restricted_builtins()
+    except Exception:  # pragma: no cover - defensive, never break rendering
+        logger.warning("failed to harden mako template builtins")
 
 
 def _shield_words(sandbox: dict, words: List[str]):

--- a/bamboo_engine/template/sandbox.py
+++ b/bamboo_engine/template/sandbox.py
@@ -83,6 +83,97 @@ def _shield_words(sandbox: dict, words: List[str]):
         sandbox[shield_word] = None
 
 
+# 绝不允许注入 ``MAKO_SANDBOX_IMPORT_MODULES`` 的模块根。
+#
+# 注入模块白名单是整个沙箱的信任根：一旦把下列任意模块注入渲染命名空间，攻击者无需触碰
+# dunder / frame，直接 ``${module.<primitive>(...)}`` 就能执行代码 / 导入 / 反序列化 /
+# 读写文件，AST deny-list 与根名白名单全部形同虚设（例如 ``operator.attrgetter('__globals__')``
+# 用字符串绕过 dunder 检查、``pickle.loads`` 反序列化、``os.system`` 直接命令执行）。
+# 这里在注入入口做一层 deny-list 兜底：即便接入方误配置，也拒绝把这些模块放进沙箱。
+DANGEROUS_IMPORT_MODULE_ROOTS = frozenset(
+    {
+        "os",
+        "sys",
+        "subprocess",
+        "importlib",
+        "imp",
+        "runpy",
+        "operator",
+        "inspect",
+        "pickle",
+        "_pickle",
+        "cpickle",
+        "marshal",
+        "shelve",
+        "dill",
+        "ctypes",
+        "cffi",
+        "pty",
+        "platform",
+        "pydoc",
+        "code",
+        "codeop",
+        "builtins",
+        "__builtin__",
+        "gc",
+        "socket",
+        "shutil",
+        "signal",
+        "multiprocessing",
+        "threading",
+        "_thread",
+        "mmap",
+        "fcntl",
+        "resource",
+        "tempfile",
+        "pdb",
+        "bdb",
+        "trace",
+        "timeit",
+        "ast",
+        "compileall",
+        "py_compile",
+    }
+)
+
+# deny-list 的例外：这些子模块本身不暴露执行原语，历史上被业务合法注入（如 ``os.path`` 的
+# ``join / exists``）。``os.path.os`` / ``os.path.sys`` 这类反向 pivot 已由 always-on 的属性
+# deny-list（``DANGEROUS_ATTR_NAMES``）拦截，因此保留 ``os.path`` 是安全的。
+SAFE_IMPORT_SUBMODULES = frozenset({"os.path"})
+
+_WARNED_DANGEROUS_IMPORTS = set()
+
+
+def _is_dangerous_import(mod_path: str) -> bool:
+    if not mod_path:
+        return False
+    if mod_path in SAFE_IMPORT_SUBMODULES:
+        return False
+    root = mod_path.split(".", 1)[0]
+    return root in DANGEROUS_IMPORT_MODULE_ROOTS
+
+
+def filter_import_modules(modules: Dict[str, str]) -> Dict[str, str]:
+    """剔除 deny-list 中的危险模块，返回可安全注入沙箱的子集。
+
+    命中危险模块时不抛异常（避免误配置直接打挂全部渲染），改为跳过 + 记录一次 error 日志，
+    保证系统 fail-safe：危险模块不会进入渲染命名空间，依赖它的模板会以 inert 形式失败并留痕。
+    """
+    safe = {}
+    for mod_path, alias in modules.items():
+        if _is_dangerous_import(mod_path):
+            if mod_path not in _WARNED_DANGEROUS_IMPORTS:
+                _WARNED_DANGEROUS_IMPORTS.add(mod_path)
+                logger.error(
+                    "refuse to inject dangerous module into mako sandbox: %s (alias=%s)",
+                    mod_path,
+                    alias,
+                )
+            continue
+        safe[mod_path] = alias
+    return safe
+
+
 class ModuleObject:
     def __init__(self, sub_paths, module):
         if len(sub_paths) == 1:
@@ -103,6 +194,7 @@ def resolve_import_object(mod_path):
 
 
 def _import_modules(sandbox: dict, modules: Dict[str, str]):
+    modules = filter_import_modules(modules)
     items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
     for mod_path, alias in items:
         obj = resolve_import_object(mod_path)

--- a/bamboo_engine/template/sandbox.py
+++ b/bamboo_engine/template/sandbox.py
@@ -35,14 +35,30 @@ class ModuleObject:
         setattr(self, sub_paths[0], ModuleObject(sub_paths[1:], module))
 
 
+def resolve_import_object(mod_path):
+    try:
+        return importlib.import_module(mod_path)
+    except ImportError:
+        parts = mod_path.split(".")
+        obj = importlib.import_module(parts[0])
+        for part in parts[1:]:
+            obj = getattr(obj, part)
+        return obj
+
+
 def _import_modules(sandbox: dict, modules: Dict[str, str]):
-    for mod_path, alias in modules.items():
-        mod = importlib.import_module(mod_path)
+    items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
+    for mod_path, alias in items:
+        obj = resolve_import_object(mod_path)
         sub_paths = alias.split(".")
         if len(sub_paths) == 1:
-            sandbox[alias] = mod
-        else:
-            sandbox[sub_paths[0]] = ModuleObject(sub_paths[1:], mod)
+            sandbox[alias] = obj
+            continue
+        root = sub_paths[0]
+        existing = sandbox.get(root)
+        if existing is not None and not isinstance(existing, ModuleObject):
+            continue
+        sandbox[root] = ModuleObject(sub_paths[1:], obj)
 
 
 def get() -> dict:

--- a/bamboo_engine/template/template.py
+++ b/bamboo_engine/template/template.py
@@ -23,6 +23,7 @@ from mako.template import Template as MakoTemplate
 from mako import lexer, codegen
 from mako.exceptions import MakoException
 
+from bamboo_engine.config import Settings
 from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
 from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 from bamboo_engine.utils import mako_safety
@@ -159,6 +160,24 @@ class Template:
             except Exception:
                 logger.exception("{} safety check error.".format(tpl))
                 continue
+            # 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``）。off 模式下保持
+            # 历史行为；warn 模式只打日志；enforce 模式命中即按 SingleLineNodeVisitor
+            # 风格 inert 掉这一段模板（``logger.warning + continue``）。
+            whitelist_mode = getattr(Settings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", "off")
+            if whitelist_mode in ("warn", "enforce"):
+                allowed_names = mako_safety.build_allowed_names(context)
+                try:
+                    check_mako_template_safety(
+                        tpl,
+                        mako_safety.WhitelistNameVisitor(allowed_names, mode=whitelist_mode),
+                        mako_safety.SingleLinCodeExtractor(),
+                    )
+                except ForbiddenMakoTemplateException as e:
+                    logger.warning("forbidden by whitelist: {}, exception: {}".format(tpl, e))
+                    continue
+                except Exception:
+                    logger.exception("{} whitelist check error.".format(tpl))
+                    continue
             resolved = Template._render_template(tpl, context)
             string = string.replace(tpl, resolved)
         return string

--- a/bamboo_engine/template/template.py
+++ b/bamboo_engine/template/template.py
@@ -205,6 +205,7 @@ class Template:
         except (MakoException, SyntaxError) as e:
             logger.error("pipeline resolve template[{}] error[{}]".format(template, e))
             return template
+        sandbox.harden_template_builtins(tm)
         try:
             resolved = tm.render_unicode(**data)
         except Exception as e:

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -14,7 +14,9 @@ specific language governing permissions and limitations under the License.
 # Mako 安全工具
 
 
-from ast import NodeVisitor
+import ast
+import logging
+import re
 
 from mako import parsetree
 
@@ -22,7 +24,127 @@ from .mako_utils.code_extract import MakoNodeCodeExtractor
 from .mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
-class SingleLineNodeVisitor(NodeVisitor):
+logger = logging.getLogger("root")
+
+# 与 ``MAKO_SANDBOX_SHIELD_WORDS`` 不重叠的"安全内建函数"集合。
+# 用于白名单模式下默认放行的根标识符。
+# 不包含 ``bytes/bytearray/frozenset/memoryview/object/type/vars/getattr/...``
+# 等常出现在 shield 列表中的内建——它们即便能通过 AST 也会在渲染期被屏蔽成 ``None``，
+# 留在白名单里只会带来认知噪音。
+SAFE_BUILTIN_NAMES = frozenset(
+    {
+        "True",
+        "False",
+        "None",
+        # 类型构造（不会构造危险对象）
+        "bool",
+        "int",
+        "float",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        # 数学 / 长度
+        "abs",
+        "round",
+        "pow",
+        "sum",
+        "min",
+        "max",
+        "len",
+        # 序列
+        "range",
+        "slice",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        # 逻辑
+        "all",
+        "any",
+    }
+)
+
+# Mako 在渲染期会向模板命名空间注入的保留对象名，用户模板里出现这些名字时
+# 极大概率是在尝试触达模板内部对象（``self.module.cache.util.os...`` SSTI 链路）。
+# 对它们直接拒绝，可以堵住绝大多数 namespace 链式 RCE 路径。
+MAKO_RESERVED_NAMESPACES = frozenset(
+    {
+        "self",
+        "context",
+        "local",
+        "parent",
+        "next",
+        "caller",
+        "pageargs",
+        "UNDEFINED",
+        "STOP_RENDERING",
+    }
+)
+
+# attr 链路上一旦出现下列名字就立刻拒绝。
+#
+# 根 ``Name`` 白名单只能防"未授权根标识符"，挡不住通过白名单根名（如 ``os``、``datetime``、
+# ``re``）反向触达危险模块的链路：
+#
+# * ``${os.path.os.popen(...)}``        — ``os.path`` 内部 ``import os``
+# * ``${datetime.sys.modules['os']...}`` — ``datetime`` 内部 ``import sys``
+# * ``${re.enum.sys.modules['os']...}``  — ``re`` 重新 export ``enum``，``enum`` 内 ``import sys``
+#
+# 所有这些链路都需要 attr 链上出现 ``os / sys / subprocess / shutil / ctypes / socket /
+# builtins / modules`` 之一，或调用 ``popen / system / exec* / spawn* / fork*`` 之一。
+# 直接把 attr 名拉黑，就能切掉公共必经路径。这是纵深防御里的"任何路径都不该带这些字"，
+# 不是替代根名白名单。
+DANGEROUS_ATTR_NAMES = frozenset(
+    {
+        # 直接拿到危险模块对象
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "ctypes",
+        "socket",
+        "_thread",
+        "threading",
+        "builtins",
+        "__builtins__",
+        # 通过模块字典反向触达任意已导入模块
+        "modules",
+        # 进程 / 文件描述符相关原语（即便有人未来误把 ``os`` 加进白名单，也再加一层）
+        "popen",
+        "popen2",
+        "popen3",
+        "popen4",
+        "system",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "kill",
+    }
+)
+
+FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
+SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class SingleLineNodeVisitor(ast.NodeVisitor):
     """
     遍历语法树节点，遇到魔术方法使用或 import 时，抛出异常
     """
@@ -30,19 +152,63 @@ class SingleLineNodeVisitor(NodeVisitor):
     def __init__(self, *args, **kwargs):
         super(SingleLineNodeVisitor, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def _get_subscript_key(node):
+        slice_node = node.slice
+        constant_node = getattr(ast, "Constant", None)
+        if (
+            constant_node is not None
+            and isinstance(slice_node, constant_node)
+            and isinstance(slice_node.value, str)
+        ):
+            return slice_node.value
+        if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):
+            return slice_node.s
+        return None
+
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Name(self, node):
         if node.id.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private method")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        subscript_key = self._get_subscript_key(node)
+        if isinstance(subscript_key, str) and subscript_key.startswith("__"):
+            raise ForbiddenMakoTemplateException("can not access private key")
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         raise ForbiddenMakoTemplateException("can not use import statement")
 
     def visit_ImportFrom(self, node):
         self.visit_Import(node)
+
+
+def validate_filter_args(filter_args):
+    for filter_arg in filter_args:
+        normalized_filter = filter_arg.strip()
+        if normalized_filter in SAFE_FILTERS:
+            continue
+        decode_filter_parts = normalized_filter.split(".")
+        if (
+            SAFE_DECODE_FILTER_PATTERN.match(normalized_filter)
+            and "__" not in normalized_filter
+            and not any(part.startswith("_") for part in decode_filter_parts[1:])
+        ):
+            continue
+        raise ForbiddenMakoTemplateException("unsupported filter expression: [{}]".format(normalized_filter))
 
 
 class SingleLinCodeExtractor(MakoNodeCodeExtractor):
@@ -53,3 +219,161 @@ class SingleLinCodeExtractor(MakoNodeCodeExtractor):
             return None
         else:
             raise ForbiddenMakoTemplateException("Unsupported node: [{}]".format(node.__class__.__name__))
+
+
+def _deformat_var_key(key):
+    """``${name}`` -> ``name``；其它 key 原样返回。"""
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def build_allowed_names(context, *, extra=()):
+    """根据当前渲染 context 与全局 ``Settings`` 计算白名单的根标识符集合。
+
+    包含：
+      * ``context`` 中的键（``${name}`` 形式自动 deformat）
+      * ``Settings.MAKO_SANDBOX_IMPORT_MODULES`` 中每个 alias 的首段
+        （例：``os.path`` → ``os``）
+      * :data:`SAFE_BUILTIN_NAMES`
+      * ``Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST``
+      * 调用方传入的 ``extra``
+    """
+    # 局部 import 避免循环依赖（``Settings`` 在 ``bamboo_engine.config``）。
+    from bamboo_engine.config import Settings
+
+    allowed = set(SAFE_BUILTIN_NAMES)
+
+    for key in context.keys() if context else ():
+        allowed.add(_deformat_var_key(key))
+
+    import_modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    for alias in import_modules.values():
+        if alias:
+            allowed.add(alias.split(".", 1)[0])
+
+    extra_whitelist = getattr(Settings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", None) or ()
+    allowed.update(extra_whitelist)
+    allowed.update(extra)
+
+    return allowed
+
+
+class WhitelistNameVisitor(ast.NodeVisitor):
+    """根标识符白名单 visitor。
+
+    只允许 Load 语义的 ``Name`` 节点引用 ``allowed_names`` 中的标识符；其余一律按
+    ``mode`` 处理：
+
+      * ``warn``：调用 ``on_violation`` / 打 warning 日志，**不抛异常**（灰度模式）。
+      * ``enforce``：抛 :exc:`ForbiddenMakoTemplateException`，由
+        :func:`bamboo_engine.utils.mako_utils.checker.check_mako_template_safety` 捕获。
+
+    本 visitor 还显式拦截 :data:`MAKO_RESERVED_NAMESPACES` 中的标识符，
+    无论是否被传入 ``allowed_names`` 都会被拒，避免误把 ``self/context/...`` 加进
+    上下文导致 SSTI 链路被放行。
+
+    支持 ``ListComp / SetComp / DictComp / GeneratorExp / Lambda`` 引入的局部
+    绑定——这些临时变量会被压入作用域栈，在子树访问完后自动弹出。
+    """
+
+    def __init__(self, allowed_names, mode="enforce", on_violation=None):
+        if mode not in {"warn", "enforce"}:
+            raise ValueError("invalid whitelist mode: {}".format(mode))
+        self.allowed_names = set(allowed_names)
+        self.mode = mode
+        self.on_violation = on_violation
+        self.scope_stack = []
+
+    def _name_allowed(self, name):
+        if name in MAKO_RESERVED_NAMESPACES:
+            return False
+        if name in self.allowed_names:
+            return True
+        for scope in self.scope_stack:
+            if name in scope:
+                return True
+        return False
+
+    def _violate(self, name, reason):
+        msg = "name not in whitelist: {} ({})".format(name, reason)
+        if self.on_violation is not None:
+            try:
+                self.on_violation(name, reason)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("on_violation callback raised")
+        if self.mode == "enforce":
+            raise ForbiddenMakoTemplateException(msg)
+        logger.warning("[mako_whitelist] %s", msg)
+
+    @staticmethod
+    def _collect_targets(target, into):
+        if isinstance(target, ast.Name):
+            into.add(target.id)
+        elif isinstance(target, ast.Starred):
+            WhitelistNameVisitor._collect_targets(target.value, into)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                WhitelistNameVisitor._collect_targets(elt, into)
+
+    def visit_Name(self, node):
+        # Store / Del 上下文是赋值/删除目标，由 _enter_* 显式处理，跳过命名检查
+        if not isinstance(node.ctx, ast.Load):
+            return
+        if node.id in MAKO_RESERVED_NAMESPACES:
+            self._violate(node.id, "mako reserved namespace")
+            return
+        if not self._name_allowed(node.id):
+            self._violate(node.id, "not in whitelist")
+
+    def visit_Attribute(self, node):
+        # 单下划线 attr 拒绝：堵 ``context._with_template / context._kwargs`` 这类
+        # Python "半私有" 通道（双下划线已经在 ``SingleLineNodeVisitor`` 拦过，这里
+        # 顺手收紧成单下划线，覆盖更广）。
+        if node.attr.startswith("_"):
+            self._violate(node.attr, "private attribute")
+            return
+        # 危险 attr 名拒绝：堵 ``${os.path.os.popen(...)}`` /
+        # ``${datetime.sys.modules['os'].popen(...)}`` 类反向引用链路。
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            self._violate(node.attr, "dangerous attribute")
+            return
+        self.generic_visit(node)
+
+    def _enter_comprehension(self, node):
+        local = set()
+        for gen in node.generators:
+            self._collect_targets(gen.target, local)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()
+
+    def visit_ListComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_SetComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_DictComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_GeneratorExp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_Lambda(self, node):
+        local = set()
+        args = node.args
+        local.update(arg.arg for arg in args.args)
+        local.update(arg.arg for arg in args.kwonlyargs)
+        local.update(arg.arg for arg in getattr(args, "posonlyargs", ()) or ())
+        if args.vararg:
+            local.add(args.vararg.arg)
+        if args.kwarg:
+            local.add(args.kwarg.arg)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -139,6 +139,50 @@ DANGEROUS_ATTR_NAMES = frozenset(
     }
 )
 
+# 生成器 / 协程 / 异步生成器 / traceback / frame 对象的反射属性。
+#
+# 这些名字都不是 ``__`` 前缀，因此逃过私有属性检查，也不在 :data:`DANGEROUS_ATTR_NAMES`
+# 里；但任意一个都能拿到一个 ``frame`` 对象，再顺着 ``frame.f_builtins`` /
+# ``frame.f_globals`` 直接取回**真实** builtins（``eval`` / ``exec`` / ``open`` /
+# ``__import__`` ...），是 deny-list 之外与配置无关的通用 RCE 入口：
+#
+#     ``${(i for i in [1]).gi_frame.f_builtins['eval']("__import__('os').system('id')")}``
+#
+# ``eval`` / ``exec`` 的实参是字符串常量，AST 不会解析其内容，所以一旦摸到 builtins
+# 字典，白名单 / 黑名单全部失效。这里把"通向 frame 的属性名"整体拒绝，从入口切断。
+FRAME_INTROSPECTION_ATTRS = frozenset(
+    {
+        # generator
+        "gi_frame",
+        "gi_code",
+        "gi_yieldfrom",
+        # coroutine
+        "cr_frame",
+        "cr_code",
+        "cr_await",
+        "cr_origin",
+        # async generator
+        "ag_frame",
+        "ag_code",
+        "ag_await",
+        # frame 对象
+        "f_back",
+        "f_builtins",
+        "f_globals",
+        "f_locals",
+        "f_code",
+        "f_trace",
+        # traceback 对象
+        "tb_frame",
+        "tb_next",
+        # 兼容老式函数内部属性别名（py2 时代，拦住无副作用）
+        "func_globals",
+        "func_code",
+        "func_closure",
+        "func_builtins",
+    }
+)
+
 FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
 SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
 SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
@@ -169,6 +213,8 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FRAME_INTROSPECTION_ATTRS:
+            raise ForbiddenMakoTemplateException("can not access frame or generator internals")
         if node.attr in FORBIDDEN_TEMPLATE_METHODS:
             raise ForbiddenMakoTemplateException("can not call forbidden method")
         self.generic_visit(node)
@@ -370,6 +416,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
             return
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
+            return
+        if node.attr in FRAME_INTROSPECTION_ATTRS:
+            self._violate(node.attr, "frame or generator internals")
             return
         kind, root, attrs = resolve_attr_chain(node)
         if kind == "name" and root in MAKO_RESERVED_NAMESPACES:

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -215,8 +215,19 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
             raise ForbiddenMakoTemplateException("can not access private attribute")
         if node.attr in FRAME_INTROSPECTION_ATTRS:
             raise ForbiddenMakoTemplateException("can not access frame or generator internals")
+        # 危险属性名（``os / sys / builtins / modules / system / popen ...``）与保留命名空间
+        # 属性链（``self.module... / context....``）改为 always-on 无条件拦截：它们原本只在
+        # ``WhitelistNameVisitor``（warn/enforce）里挡，导致 ``off`` 模式下仍可用
+        # ``${self.module.cache.util.os.system(...)}`` / ``${os.path.os.system(...)}`` /
+        # ``${json.codecs.builtins.exec(...)}`` 反向 pivot 到真实模块拿 RCE。这里下沉到
+        # ``SingleLineNodeVisitor``，任何模式（含 off）都切断这两条公共必经路径。
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            raise ForbiddenMakoTemplateException("can not access dangerous attribute")
         if node.attr in FORBIDDEN_TEMPLATE_METHODS:
             raise ForbiddenMakoTemplateException("can not call forbidden method")
+        root_kind, root_name, _attrs = resolve_attr_chain(node)
+        if root_kind == "name" and root_name in MAKO_RESERVED_NAMESPACES:
+            raise ForbiddenMakoTemplateException("can not access mako reserved namespace attribute")
         self.generic_visit(node)
 
     def visit_Name(self, node):

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -228,6 +228,45 @@ def _deformat_var_key(key):
     return key
 
 
+def resolve_attr_chain(node):
+    attrs = [node.attr]
+    cur = node.value
+    while isinstance(cur, ast.Attribute):
+        attrs.append(cur.attr)
+        cur = cur.value
+    attrs.reverse()
+    if isinstance(cur, ast.Name):
+        return "name", cur.id, attrs
+    if isinstance(cur, ast.Call):
+        return "call_result", None, attrs
+    return "other", None, attrs
+
+
+def import_chain_violation(root, attrs, aliases):
+    if not root:
+        return None
+    roots = set(alias.split(".", 1)[0] for alias in aliases)
+    if root not in roots:
+        return None
+    best_len = -1
+    for index in range(len(attrs) + 1):
+        candidate = root if index == 0 else "{}.{}".format(root, ".".join(attrs[:index]))
+        if candidate in aliases:
+            best_len = index
+    if best_len < 0:
+        return "import path not configured"
+    if len(attrs[best_len:]) > 1:
+        return "import attr deeper than one level"
+    return None
+
+
+def configured_import_aliases():
+    from bamboo_engine.config import Settings
+
+    modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    return frozenset(alias for alias in modules.values() if alias)
+
+
 def build_allowed_names(context, *, extra=()):
     """根据当前渲染 context 与全局 ``Settings`` 计算白名单的根标识符集合。
 
@@ -269,9 +308,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
       * ``enforce``：抛 :exc:`ForbiddenMakoTemplateException`，由
         :func:`bamboo_engine.utils.mako_utils.checker.check_mako_template_safety` 捕获。
 
-    本 visitor 还显式拦截 :data:`MAKO_RESERVED_NAMESPACES` 中的标识符，
-    无论是否被传入 ``allowed_names`` 都会被拒，避免误把 ``self/context/...`` 加进
-    上下文导致 SSTI 链路被放行。
+    光杆保留名（:data:`MAKO_RESERVED_NAMESPACES`）放行；保留名上的属性链仍拒，
+    避免 ``self.module...`` 一类 SSTI 链路被放行。单下划线 attr 不再一刀切，
+    仅双下划线与 :data:`DANGEROUS_ATTR_NAMES` 在属性节点上拦截。
 
     支持 ``ListComp / SetComp / DictComp / GeneratorExp / Lambda`` 引入的局部
     绑定——这些临时变量会被压入作用域栈，在子树访问完后自动弹出。
@@ -321,23 +360,26 @@ class WhitelistNameVisitor(ast.NodeVisitor):
         if not isinstance(node.ctx, ast.Load):
             return
         if node.id in MAKO_RESERVED_NAMESPACES:
-            self._violate(node.id, "mako reserved namespace")
             return
         if not self._name_allowed(node.id):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
-        # 单下划线 attr 拒绝：堵 ``context._with_template / context._kwargs`` 这类
-        # Python "半私有" 通道（双下划线已经在 ``SingleLineNodeVisitor`` 拦过，这里
-        # 顺手收紧成单下划线，覆盖更广）。
-        if node.attr.startswith("_"):
+        if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return
-        # 危险 attr 名拒绝：堵 ``${os.path.os.popen(...)}`` /
-        # ``${datetime.sys.modules['os'].popen(...)}`` 类反向引用链路。
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
             return
+        kind, root, attrs = resolve_attr_chain(node)
+        if kind == "name" and root in MAKO_RESERVED_NAMESPACES:
+            self._violate(root, "mako reserved namespace attribute")
+            return
+        if kind == "name":
+            reason = import_chain_violation(root, attrs, configured_import_aliases())
+            if reason:
+                self._violate(root, reason)
+                return
         self.generic_visit(node)
 
     def _enter_comprehension(self, node):

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -183,7 +183,8 @@ FRAME_INTROSPECTION_ATTRS = frozenset(
     }
 )
 
-FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+# .format 保留 off/warn 下的存量兼容，仅 enforce 检查；format_map 仍始终拒绝。
+FORBIDDEN_TEMPLATE_METHODS = {"format_map"}
 SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
 SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
@@ -422,6 +423,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
+        if self.mode == "enforce" and node.attr == "format":
+            self._violate(node.attr, "forbidden method")
+            return
         if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return

--- a/bamboo_engine/utils/mako_utils/checker.py
+++ b/bamboo_engine/utils/mako_utils/checker.py
@@ -19,8 +19,19 @@ from mako import parsetree
 from mako.exceptions import MakoException
 from mako.lexer import Lexer
 
+from bamboo_engine.utils import mako_safety
+
 from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
+
+
+def validate_node_filter_callables(node: parsetree.Node):
+    # Mako stores inline `${expr | ...}` filter callables in `escapes_code`;
+    # tag-level filters use `filter_args`. Both are executed by create_filter_callable().
+    if hasattr(node, "escapes_code"):
+        mako_safety.validate_filter_args(node.escapes_code.args)
+    if hasattr(node, "filter_args"):
+        mako_safety.validate_filter_args(node.filter_args.args)
 
 
 def parse_template_nodes(
@@ -35,14 +46,15 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        code = code_extractor.extract(node)
-        if code is None:
-            continue
+        validate_node_filter_callables(node)
 
-        ast_node = ast.parse(code, "<unknown>", "exec")
-        node_visitor.visit(ast_node)
+        code = code_extractor.extract(node)
+        if code is not None:
+            ast_node = ast.parse(code, "<unknown>", "exec")
+            node_visitor.visit(ast_node)
+
         if hasattr(node, "nodes"):
-            parse_template_nodes(node.nodes, node_visitor)
+            parse_template_nodes(node.nodes, node_visitor, code_extractor)
 
 
 def check_mako_template_safety(text: str, node_visitor: ast.NodeVisitor, code_extractor: MakoNodeCodeExtractor) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-engine"
-version = "2.6.5"
+version = "2.6.6"
 description = "Bamboo-engine is a general-purpose workflow engine"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"

--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "3.24.16"
+__version__ = "3.24.17"

--- a/runtime/bamboo-pipeline/pipeline/conf/default_settings.py
+++ b/runtime/bamboo-pipeline/pipeline/conf/default_settings.py
@@ -88,7 +88,53 @@ EXPIRED_TASK_CLEAN_NUM_LIMIT = getattr(settings, "EXPIRED_TASK_CLEAN_NUM_LIMIT",
 TASK_EXPIRED_MONTH = getattr(settings, "TASK_EXPIRED_MONTH", 6)
 
 # MAKO sandbox config
-MAKO_SANDBOX_SHIELD_WORDS = getattr(settings, "MAKO_SANDBOX_SHIELD_WORDS", [])
+# 默认屏蔽所有可被用于 SSTI 链路的内建可调用名字（getattr/eval/exec/open/type/__import__ 等）。
+# 这是一份与 ``bamboo_engine.config.Settings.MAKO_SANDBOX_SHIELD_WORDS`` 保持同步的安全兜底，
+# 任何未显式设置 ``MAKO_SANDBOX_SHIELD_WORDS`` 的 Django 宿主也能开箱即得到屏蔽。
+DEFAULT_MAKO_SANDBOX_SHIELD_WORDS = [
+    "ascii",
+    "breakpoint",
+    "bytearray",
+    "bytes",
+    "callable",
+    "chr",
+    "classmethod",
+    "compile",
+    "delattr",
+    "dir",
+    "divmod",
+    "exec",
+    "eval",
+    "filter",
+    "format",
+    "frozenset",
+    "getattr",
+    "globals",
+    "hasattr",
+    "hash",
+    "help",
+    "id",
+    "input",
+    "isinstance",
+    "issubclass",
+    "iter",
+    "locals",
+    "map",
+    "memoryview",
+    "next",
+    "object",
+    "open",
+    "print",
+    "property",
+    "repr",
+    "setattr",
+    "staticmethod",
+    "super",
+    "type",
+    "vars",
+    "__import__",
+]
+MAKO_SANDBOX_SHIELD_WORDS = getattr(settings, "MAKO_SANDBOX_SHIELD_WORDS", DEFAULT_MAKO_SANDBOX_SHIELD_WORDS)
 MAKO_SANDBOX_IMPORT_MODULES = getattr(settings, "MAKO_SANDBOX_IMPORT_MODULES", {})
 MAKO_SAFETY_CHECK = getattr(settings, "MAKO_SAFETY_CHECK", True)
 

--- a/runtime/bamboo-pipeline/pipeline/core/data/expression.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/expression.py
@@ -141,6 +141,26 @@ class ConstantTemplate(object):
                 except Exception:
                     logger.exception("{} safety check error.".format(tpl))
                     continue
+                # 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``），延用引擎全局
+                # ``Settings`` 配置；off 时保持历史行为，warn 仅打日志，enforce 命中即
+                # 按 SingleLineNodeVisitor 风格 inert 掉这一段模板。
+                from bamboo_engine.config import Settings as _BambooSettings
+
+                whitelist_mode = getattr(_BambooSettings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", "off")
+                if whitelist_mode in ("warn", "enforce"):
+                    allowed_names = mako_safety.build_allowed_names(value_maps)
+                    try:
+                        check_mako_template_safety(
+                            tpl,
+                            mako_safety.WhitelistNameVisitor(allowed_names, mode=whitelist_mode),
+                            mako_safety.SingleLinCodeExtractor(),
+                        )
+                    except ForbiddenMakoTemplateException as e:
+                        logger.warning("forbidden by whitelist: {}, exception: {}".format(tpl, e))
+                        continue
+                    except Exception:
+                        logger.exception("{} whitelist check error.".format(tpl))
+                        continue
             resolved = ConstantTemplate.resolve_template(tpl, value_maps)
             string = string.replace(tpl, resolved)
         return string

--- a/runtime/bamboo-pipeline/pipeline/core/data/expression.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/expression.py
@@ -19,6 +19,7 @@ from mako.template import Template
 from mako import lexer, codegen
 from mako.exceptions import MakoException
 
+from bamboo_engine.template.sandbox import harden_template_builtins
 from pipeline import exceptions
 from pipeline.conf.default_settings import MAKO_SAFETY_CHECK
 from pipeline.core.data.sandbox import SANDBOX
@@ -177,6 +178,7 @@ class ConstantTemplate(object):
         except (MakoException, SyntaxError) as e:
             logger.error("pipeline resolve template[{}] error[{}]".format(template, e))
             return template
+        harden_template_builtins(tm)
         try:
             resolved = tm.render_unicode(**data)
         except Exception as e:

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -17,6 +17,7 @@ import re
 from mako import parsetree
 
 from bamboo_engine.utils.mako_safety import (
+    FRAME_INTROSPECTION_ATTRS,
     configured_import_aliases,
     import_chain_violation,
     resolve_attr_chain,
@@ -146,6 +147,8 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FRAME_INTROSPECTION_ATTRS:
+            raise ForbiddenMakoTemplateException("can not access frame or generator internals")
         if node.attr in FORBIDDEN_TEMPLATE_METHODS:
             raise ForbiddenMakoTemplateException("can not call forbidden method")
         self.generic_visit(node)
@@ -298,6 +301,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
             return
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
+            return
+        if node.attr in FRAME_INTROSPECTION_ATTRS:
+            self._violate(node.attr, "frame or generator internals")
             return
         kind, root, attrs = resolve_attr_chain(node)
         if kind == "name" and root in MAKO_RESERVED_NAMESPACES:

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -149,8 +149,16 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
             raise ForbiddenMakoTemplateException("can not access private attribute")
         if node.attr in FRAME_INTROSPECTION_ATTRS:
             raise ForbiddenMakoTemplateException("can not access frame or generator internals")
+        # 与 ``bamboo_engine.utils.mako_safety.SingleLineNodeVisitor`` 对齐：危险属性名与保留
+        # 命名空间属性链下沉为 always-on 无条件拦截，堵住 off 模式下的模块反向 pivot 与
+        # ``self.module...`` 链路。
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            raise ForbiddenMakoTemplateException("can not access dangerous attribute")
         if node.attr in FORBIDDEN_TEMPLATE_METHODS:
             raise ForbiddenMakoTemplateException("can not call forbidden method")
+        root_kind, root_name, _attrs = resolve_attr_chain(node)
+        if root_kind == "name" and root_name in MAKO_RESERVED_NAMESPACES:
+            raise ForbiddenMakoTemplateException("can not access mako reserved namespace attribute")
         self.generic_visit(node)
 
     def visit_Name(self, node):

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -16,6 +16,11 @@ import re
 
 from mako import parsetree
 
+from bamboo_engine.utils.mako_safety import (
+    configured_import_aliases,
+    import_chain_violation,
+    resolve_attr_chain,
+)
 from pipeline.utils.mako_utils.code_extract import MakoNodeCodeExtractor
 from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
@@ -283,20 +288,26 @@ class WhitelistNameVisitor(ast.NodeVisitor):
         if not isinstance(node.ctx, ast.Load):
             return
         if node.id in MAKO_RESERVED_NAMESPACES:
-            self._violate(node.id, "mako reserved namespace")
             return
         if not self._name_allowed(node.id):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
-        # 与新引擎 ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor.visit_Attribute``
-        # 保持一致：单下划线前缀 + 危险 attr 名一律拒绝，堵反向引用 SSTI 链路。
-        if node.attr.startswith("_"):
+        if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
             return
+        kind, root, attrs = resolve_attr_chain(node)
+        if kind == "name" and root in MAKO_RESERVED_NAMESPACES:
+            self._violate(root, "mako reserved namespace attribute")
+            return
+        if kind == "name":
+            reason = import_chain_violation(root, attrs, configured_import_aliases())
+            if reason:
+                self._violate(root, reason)
+                return
         self.generic_visit(node)
 
     def _enter_comprehension(self, node):

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -10,8 +10,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-from ast import NodeVisitor
+import ast
+import logging
+import re
 
 from mako import parsetree
 
@@ -19,7 +20,103 @@ from pipeline.utils.mako_utils.code_extract import MakoNodeCodeExtractor
 from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
-class SingleLineNodeVisitor(NodeVisitor):
+logger = logging.getLogger("root")
+
+# 与 ``MAKO_SANDBOX_SHIELD_WORDS`` 不重叠的"安全内建函数"集合，详见
+# ``bamboo_engine.utils.mako_safety.SAFE_BUILTIN_NAMES``。
+SAFE_BUILTIN_NAMES = frozenset(
+    {
+        "True",
+        "False",
+        "None",
+        "bool",
+        "int",
+        "float",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        "abs",
+        "round",
+        "pow",
+        "sum",
+        "min",
+        "max",
+        "len",
+        "range",
+        "slice",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        "all",
+        "any",
+    }
+)
+
+# Mako 渲染期保留命名空间，详见 ``bamboo_engine.utils.mako_safety.MAKO_RESERVED_NAMESPACES``。
+MAKO_RESERVED_NAMESPACES = frozenset(
+    {
+        "self",
+        "context",
+        "local",
+        "parent",
+        "next",
+        "caller",
+        "pageargs",
+        "UNDEFINED",
+        "STOP_RENDERING",
+    }
+)
+
+# attr 链路危险字段，详见 ``bamboo_engine.utils.mako_safety.DANGEROUS_ATTR_NAMES``。
+DANGEROUS_ATTR_NAMES = frozenset(
+    {
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "ctypes",
+        "socket",
+        "_thread",
+        "threading",
+        "builtins",
+        "__builtins__",
+        "modules",
+        "popen",
+        "popen2",
+        "popen3",
+        "popen4",
+        "system",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "kill",
+    }
+)
+
+FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
+SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class SingleLineNodeVisitor(ast.NodeVisitor):
     """
     遍历语法树节点，遇到魔术方法使用或 import 时，抛出异常
     """
@@ -27,19 +124,72 @@ class SingleLineNodeVisitor(NodeVisitor):
     def __init__(self, *args, **kwargs):
         super(SingleLineNodeVisitor, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def _get_subscript_key(node):
+        slice_node = node.slice
+        constant_node = getattr(ast, "Constant", None)
+        if (
+            constant_node is not None
+            and isinstance(slice_node, constant_node)
+            and isinstance(slice_node.value, str)
+        ):
+            return slice_node.value
+        if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):
+            return slice_node.s
+        return None
+
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Name(self, node):
         if node.id.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private method")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        subscript_key = self._get_subscript_key(node)
+        if isinstance(subscript_key, str) and subscript_key.startswith("__"):
+            raise ForbiddenMakoTemplateException("can not access private key")
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         raise ForbiddenMakoTemplateException("can not use import statement")
 
     def visit_ImportFrom(self, node):
         self.visit_Import(node)
+
+
+def validate_filter_args(filter_args):
+    """对 ``${expr | filter}`` 与 tag-level ``filter=`` 的 filter callable 做白名单校验。
+
+    Mako 在渲染期会把 filter 表达式作为 Python 代码 ``eval`` 出 callable，因此必须在
+    parse 阶段就拒绝任意 Python 表达式，否则攻击者可以通过 ``(side_effect() or str)``
+    这种 filter 表达式绕过主表达式上的 AST 检查。
+    """
+
+    for filter_arg in filter_args:
+        normalized_filter = filter_arg.strip()
+        if not normalized_filter:
+            continue
+        if normalized_filter in SAFE_FILTERS:
+            continue
+        decode_filter_parts = normalized_filter.split(".")
+        if (
+            SAFE_DECODE_FILTER_PATTERN.match(normalized_filter)
+            and "__" not in normalized_filter
+            and not any(part.startswith("_") for part in decode_filter_parts[1:])
+        ):
+            continue
+        raise ForbiddenMakoTemplateException("unsupported filter expression: [{}]".format(normalized_filter))
 
 
 class SingleLinCodeExtractor(MakoNodeCodeExtractor):
@@ -50,3 +200,139 @@ class SingleLinCodeExtractor(MakoNodeCodeExtractor):
             return None
         else:
             raise ForbiddenMakoTemplateException("Unsupported node: [{}]".format(node.__class__.__name__))
+
+
+def _deformat_var_key(key):
+    """``${name}`` -> ``name``；其它 key 原样返回。"""
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def build_allowed_names(context, *, extra=()):
+    """legacy 模板渲染白名单根标识符集合。
+
+    与 ``bamboo_engine.utils.mako_safety.build_allowed_names`` 行为一致：
+    复用 ``bamboo_engine.config.Settings`` 上的 ``MAKO_SANDBOX_IMPORT_MODULES /
+    MAKO_TEMPLATE_NAME_EXTRA_WHITELIST`` 配置，避免接入方维护两套白名单源。
+    """
+    from bamboo_engine.config import Settings
+
+    allowed = set(SAFE_BUILTIN_NAMES)
+
+    for key in context.keys() if context else ():
+        allowed.add(_deformat_var_key(key))
+
+    import_modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    for alias in import_modules.values():
+        if alias:
+            allowed.add(alias.split(".", 1)[0])
+
+    extra_whitelist = getattr(Settings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", None) or ()
+    allowed.update(extra_whitelist)
+    allowed.update(extra)
+
+    return allowed
+
+
+class WhitelistNameVisitor(ast.NodeVisitor):
+    """legacy 渲染路径用的白名单 visitor，行为对齐
+    ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor``。
+    """
+
+    def __init__(self, allowed_names, mode="enforce", on_violation=None):
+        if mode not in {"warn", "enforce"}:
+            raise ValueError("invalid whitelist mode: {}".format(mode))
+        self.allowed_names = set(allowed_names)
+        self.mode = mode
+        self.on_violation = on_violation
+        self.scope_stack = []
+
+    def _name_allowed(self, name):
+        if name in MAKO_RESERVED_NAMESPACES:
+            return False
+        if name in self.allowed_names:
+            return True
+        for scope in self.scope_stack:
+            if name in scope:
+                return True
+        return False
+
+    def _violate(self, name, reason):
+        msg = "name not in whitelist: {} ({})".format(name, reason)
+        if self.on_violation is not None:
+            try:
+                self.on_violation(name, reason)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("on_violation callback raised")
+        if self.mode == "enforce":
+            raise ForbiddenMakoTemplateException(msg)
+        logger.warning("[mako_whitelist] %s", msg)
+
+    @staticmethod
+    def _collect_targets(target, into):
+        if isinstance(target, ast.Name):
+            into.add(target.id)
+        elif isinstance(target, ast.Starred):
+            WhitelistNameVisitor._collect_targets(target.value, into)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                WhitelistNameVisitor._collect_targets(elt, into)
+
+    def visit_Name(self, node):
+        if not isinstance(node.ctx, ast.Load):
+            return
+        if node.id in MAKO_RESERVED_NAMESPACES:
+            self._violate(node.id, "mako reserved namespace")
+            return
+        if not self._name_allowed(node.id):
+            self._violate(node.id, "not in whitelist")
+
+    def visit_Attribute(self, node):
+        # 与新引擎 ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor.visit_Attribute``
+        # 保持一致：单下划线前缀 + 危险 attr 名一律拒绝，堵反向引用 SSTI 链路。
+        if node.attr.startswith("_"):
+            self._violate(node.attr, "private attribute")
+            return
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            self._violate(node.attr, "dangerous attribute")
+            return
+        self.generic_visit(node)
+
+    def _enter_comprehension(self, node):
+        local = set()
+        for gen in node.generators:
+            self._collect_targets(gen.target, local)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()
+
+    def visit_ListComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_SetComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_DictComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_GeneratorExp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_Lambda(self, node):
+        local = set()
+        args = node.args
+        local.update(arg.arg for arg in args.args)
+        local.update(arg.arg for arg in args.kwonlyargs)
+        local.update(arg.arg for arg in getattr(args, "posonlyargs", ()) or ())
+        if args.vararg:
+            local.add(args.vararg.arg)
+        if args.kwarg:
+            local.add(args.kwarg.arg)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -117,7 +117,8 @@ DANGEROUS_ATTR_NAMES = frozenset(
     }
 )
 
-FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+# .format 保留 off/warn 下的存量兼容，仅 enforce 检查；format_map 仍始终拒绝。
+FORBIDDEN_TEMPLATE_METHODS = {"format_map"}
 SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
 SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
@@ -304,6 +305,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
+        if self.mode == "enforce" and node.attr == "format":
+            self._violate(node.attr, "forbidden method")
+            return
         if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return

--- a/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
 # mock str return value of Built-in Functions，make str(func) return "func" rather than "<built-in function func>"
 
 import builtins
-import importlib
 
+from bamboo_engine.template.sandbox import resolve_import_object
 from pipeline.conf import default_settings
 
 SANDBOX = {}
@@ -48,13 +48,18 @@ class ModuleObject:
 
 
 def _import_modules(sandbox, modules):
-    for mod_path, alias in modules.items():
-        mod = importlib.import_module(mod_path)
+    items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
+    for mod_path, alias in items:
+        obj = resolve_import_object(mod_path)
         sub_paths = alias.split(".")
         if len(sub_paths) == 1:
-            sandbox[alias] = mod
-        else:
-            sandbox[sub_paths[0]] = ModuleObject(sub_paths[1:], mod)
+            sandbox[alias] = obj
+            continue
+        root = sub_paths[0]
+        existing = sandbox.get(root)
+        if existing is not None and not isinstance(existing, ModuleObject):
+            continue
+        sandbox[root] = ModuleObject(sub_paths[1:], obj)
 
 
 def _mock_builtins():

--- a/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
 
 import builtins
 
-from bamboo_engine.template.sandbox import resolve_import_object
+from bamboo_engine.template.sandbox import filter_import_modules, resolve_import_object
 from pipeline.conf import default_settings
 
 SANDBOX = {}
@@ -48,6 +48,7 @@ class ModuleObject:
 
 
 def _import_modules(sandbox, modules):
+    modules = filter_import_modules(modules)
     items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
     for mod_path, alias in items:
         obj = resolve_import_object(mod_path)

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -275,16 +275,43 @@ class TestMakoNameWhitelist(TestCase):
         finally:
             self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
 
-    def test_single_underscore_attr_blocked(self):
+    def test_reserved_namespace_attributes_blocked(self):
         self._set_mode("enforce")
         for p in [
             "${context._kwargs}",
             "${context._with_template}",
-            "${obj._secret}",
         ]:
             with self.subTest(payload=p):
-                rendered = expression.ConstantTemplate(p).resolve_data({"obj": object()})
+                rendered = expression.ConstantTemplate(p).resolve_data({})
                 self.assertEqual(rendered, p)
+
+    def test_user_single_underscore_attr_allowed(self):
+        self._set_mode("enforce")
+
+        class Bag(object):
+            def __init__(self):
+                self._module = [{"gamesvr": "1.1.1.1"}]
+
+        rendered = expression.ConstantTemplate("${obj._module[0]['gamesvr']}").resolve_data({"obj": Bag()})
+        self.assertEqual(rendered, "1.1.1.1")
+
+    def test_bare_caller_allowed(self):
+        self._set_mode("enforce")
+        # ConstantTemplate 对光杆 ``${caller}`` 会按 context 键短路，AST 走不到 visitor。
+        self.assertEqual(
+            expression.ConstantTemplate("${parent + ''}").resolve_data({"parent": "alice"}),
+            "alice",
+        )
+
+    def test_import_deep_chain_blocked(self):
+        self._set_mode("enforce")
+        original = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {"json": "json"}
+        try:
+            payload = "${json.codecs.builtins.exec('1')}"
+            self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original
 
     def test_business_patterns_still_render(self):
         self._set_mode("enforce")

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -236,11 +236,13 @@ class TestMakoNameWhitelist(TestCase):
         self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
         self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
 
-    def test_off_mode_keeps_legacy_behavior(self):
+    def test_off_mode_also_blocks_self_module(self):
+        # 保留命名空间属性链下沉 always-on 后，off 模式也 inert
+        # （此前 off 会解析出真实 os 模块执行命令，这里回归为拦截）。
         self._set_mode("off")
         payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
         rendered = expression.ConstantTemplate(payload).resolve_data({})
-        self.assertIn("OFF", rendered)
+        self.assertEqual(rendered, payload)
 
     def test_default_mode_blocks_self_module(self):
         payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
@@ -345,6 +347,36 @@ class TestMakoNameWhitelist(TestCase):
                 self._set_mode(mode)
                 self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
 
+    def test_dangerous_attr_chain_blocked_all_modes(self):
+        # 危险属性名下沉 always-on 后，模块反向 pivot 在 off / warn / enforce 三档都 inert。
+        original_imports = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {
+            "datetime": "datetime",
+            "re": "re",
+            "os.path": "os.path",
+            "json": "json",
+        }
+        payloads = [
+            '${os.path.os.system("echo PWNED")}',
+            '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+            '${json.codecs.builtins.exec("import os")}',
+        ]
+        try:
+            for mode in ("off", "warn", "enforce"):
+                for p in payloads:
+                    with self.subTest(mode=mode, payload=p):
+                        self._set_mode(mode)
+                        self.assertEqual(expression.ConstantTemplate(p).resolve_data({}), p)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+    def test_reserved_namespace_chain_blocked_all_modes(self):
+        for mode in ("off", "warn", "enforce"):
+            for p in ("${context.lookup}", "${local.something}", "${parent.foo}"):
+                with self.subTest(mode=mode, payload=p):
+                    self._set_mode(mode)
+                    self.assertEqual(expression.ConstantTemplate(p).resolve_data({}), p)
+
 
 class TestMakoSafetyHardening(TestCase):
     def _assert_forbidden(self, payload):
@@ -430,3 +462,33 @@ class TestMakoSafetyHardening(TestCase):
             self.assertNotIn(name, rb)
         for name in ("len", "str", "range", "int", "__import__"):
             self.assertIn(name, rb)
+
+    def test_dangerous_attr_names_are_blocked_always_on(self):
+        for attr in ("os", "sys", "subprocess", "builtins", "modules", "system", "popen", "kill"):
+            with self.subTest(attr=attr):
+                self._assert_forbidden("${obj.%s}" % attr)
+
+    def test_reserved_namespace_chain_is_blocked_always_on(self):
+        for payload in (
+            '${self.module.cache.util}',
+            "${context.lookup}",
+            "${local.x}",
+            "${parent.foo}",
+            "${caller.body()}",
+            "${pageargs.x}",
+        ):
+            with self.subTest(payload=payload):
+                self._assert_forbidden(payload)
+
+    def test_filter_import_modules_rejects_dangerous_keeps_safe(self):
+        from bamboo_engine.template import sandbox as engine_sandbox
+
+        src = {
+            "os": "os",
+            "subprocess": "subprocess",
+            "operator": "operator",
+            "pickle": "pickle",
+            "os.path": "os.path",
+            "json": "json",
+        }
+        self.assertEqual(set(engine_sandbox.filter_import_modules(src)), {"os.path", "json"})

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -59,10 +59,12 @@ class TestConstantTemplate(TestCase):
 
     def test_resolve_template_with_curly_braces(self):
         cons_tmpl = expression.ConstantTemplate("")
-        one_template = '${"test_{}".format(a)}'
-        self.assertEqual(cons_tmpl.resolve_string(one_template, {"a": "1"}), "test_1")
-        ano_template = '${f"test_{a}"}'
-        self.assertEqual(cons_tmpl.resolve_template(ano_template, {"a": "2"}), "test_2")
+        format_attr_template = '${"test_{}".format(a)}'
+        self.assertEqual(cons_tmpl.resolve_string(format_attr_template, {"a": "1"}), format_attr_template)
+        percent_template = '${"test_%s" % a}'
+        self.assertEqual(cons_tmpl.resolve_string(percent_template, {"a": "1"}), "test_1")
+        fstring_template = '${f"test_{a}"}'
+        self.assertEqual(cons_tmpl.resolve_template(fstring_template, {"a": "2"}), "test_2")
 
     def test_resolve_string(self):
         cons_tmpl = expression.ConstantTemplate("")

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -16,8 +16,10 @@ import datetime
 
 from django.test import TestCase
 
-from pipeline.core.data import expression, sandbox
+from pipeline.core.data import expression, mako_safety, sandbox
 from pipeline.core.data.expression import format_constant_key, deformat_constant_key
+from pipeline.utils.mako_utils.checker import check_mako_template_safety
+from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
 class TestConstantTemplate(TestCase):
@@ -214,3 +216,151 @@ class TestConstantTemplate(TestCase):
             self.assertEqual(expression.ConstantTemplate(at).resolve_data({}), at)
 
         sandbox.SANDBOX = sandbox_copy
+
+
+class TestMakoNameWhitelist(TestCase):
+    def setUp(self):
+        from bamboo_engine.config import Settings as BambooSettings
+
+        self._BambooSettings = BambooSettings
+        self._original_mode = BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE
+        self._original_extra = BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
+    def tearDown(self):
+        self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = self._original_mode
+        self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = self._original_extra
+
+    def _set_mode(self, mode, extra=()):
+        self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
+        self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
+
+    def test_off_mode_keeps_legacy_behavior(self):
+        self._set_mode("off")
+        payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertIn("OFF", rendered)
+
+    def test_default_mode_blocks_self_module(self):
+        payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertEqual(rendered, payload)
+
+    def test_enforce_blocks_self_module(self):
+        self._set_mode("enforce")
+        payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertEqual(rendered, payload)
+
+    def test_dangerous_attr_chain_blocked(self):
+        self._set_mode("enforce")
+        original_imports = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {
+            "datetime": "datetime",
+            "re": "re",
+            "os.path": "os.path",
+        }
+        try:
+            payloads = [
+                '${os.path.os.popen("echo PWNED").read()}',
+                '${os.path.genericpath.os.popen("echo PWNED").read()}',
+                '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+                '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+            ]
+            for p in payloads:
+                with self.subTest(payload=p):
+                    rendered = expression.ConstantTemplate(p).resolve_data({})
+                    self.assertEqual(rendered, p)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+    def test_single_underscore_attr_blocked(self):
+        self._set_mode("enforce")
+        for p in [
+            "${context._kwargs}",
+            "${context._with_template}",
+            "${obj._secret}",
+        ]:
+            with self.subTest(payload=p):
+                rendered = expression.ConstantTemplate(p).resolve_data({"obj": object()})
+                self.assertEqual(rendered, p)
+
+    def test_business_patterns_still_render(self):
+        self._set_mode("enforce")
+        cases = [
+            ("${name.upper()}", {"name": "abc"}, "ABC"),
+            ("${[x * 2 for x in items]}", {"items": [1, 2, 3]}, "[2, 4, 6]"),
+            ("${(lambda y: y + 1)(seed)}", {"seed": 4}, "5"),
+            ("${len(items)}", {"items": [1, 2]}, "2"),
+        ]
+        for tpl, ctx, expected in cases:
+            with self.subTest(tpl=tpl):
+                self.assertEqual(expression.ConstantTemplate(tpl).resolve_data(ctx), expected)
+
+    def test_extra_whitelist_names(self):
+        self._set_mode("enforce", extra=("_loop", "_system"))
+        self.assertEqual(expression.ConstantTemplate("${_loop}").resolve_data({"_loop": 3}), 3)
+        self.assertEqual(expression.ConstantTemplate("${_loop + 1}").resolve_data({"_loop": 4}), "5")
+
+    def test_unknown_root_name_blocked(self):
+        self._set_mode("enforce")
+        payload = "${secret_var}"
+        self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+
+
+class TestMakoSafetyHardening(TestCase):
+    def _assert_forbidden(self, payload):
+        with self.assertRaises(ForbiddenMakoTemplateException):
+            check_mako_template_safety(
+                payload,
+                mako_safety.SingleLineNodeVisitor(),
+                mako_safety.SingleLinCodeExtractor(),
+            )
+
+    def _assert_allowed(self, payload):
+        check_mako_template_safety(
+            payload,
+            mako_safety.SingleLineNodeVisitor(),
+            mako_safety.SingleLinCodeExtractor(),
+        )
+
+    def test_filter_callable_with_side_effect_is_blocked(self):
+        self._assert_forbidden("${'x'|((side_effect() or str))}")
+
+    def test_filter_with_dunder_chain_is_blocked(self):
+        self._assert_forbidden("${'x'|().__class__.__bases__[0].__subclasses__}")
+
+    def test_filter_list_with_malicious_item_is_blocked(self):
+        self._assert_forbidden("${'x'|h, (side_effect() or str)}")
+
+    def test_decode_filter_with_dunder_is_blocked(self):
+        self._assert_forbidden("${'x'|decode.__class__}")
+
+    def test_tag_level_expression_filter_is_blocked(self):
+        self._assert_forbidden('<%page expression_filter="(side_effect() or str)"/>${name}')
+
+    def test_tag_level_def_filter_is_blocked(self):
+        payload = '<%def name="r(x)" filter="(side_effect() or str)">${x}</%def>${r("x")}'
+        self._assert_forbidden(payload)
+
+    def test_tag_level_block_filter_is_blocked(self):
+        self._assert_forbidden('<%block filter="(side_effect() or str)">x</%block>')
+
+    def test_tag_level_text_filter_is_blocked(self):
+        self._assert_forbidden('<%text filter="(side_effect() or str)">x</%text>')
+
+    def test_format_attribute_call_is_blocked(self):
+        self._assert_forbidden('${"{0.__class__}".format("")}')
+
+    def test_format_map_attribute_call_is_blocked(self):
+        self._assert_forbidden('${"{value.__class__}".format_map({"value": ""})}')
+
+    def test_builtin_filters_remain_allowed(self):
+        for payload in [
+            "${' x ' | h}",
+            "${' x ' | trim}",
+            "${' x ' | h, trim}",
+            "${'x' | n}",
+            "${b'abc' | decode.utf8}",
+        ]:
+            with self.subTest(payload=payload):
+                self._assert_allowed(payload)

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -335,6 +335,16 @@ class TestMakoNameWhitelist(TestCase):
         payload = "${secret_var}"
         self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
 
+    def test_generator_frame_gadget_blocked_all_modes(self):
+        payload = (
+            "${(i for i in [1]).gi_frame.f_builtins['eval']"
+            "(\"__import__('os').popen('echo PWNED').read()\")}"
+        )
+        for mode in ("off", "warn", "enforce"):
+            with self.subTest(mode=mode):
+                self._set_mode(mode)
+                self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+
 
 class TestMakoSafetyHardening(TestCase):
     def _assert_forbidden(self, payload):
@@ -393,3 +403,30 @@ class TestMakoSafetyHardening(TestCase):
         ]:
             with self.subTest(payload=payload):
                 self._assert_allowed(payload)
+
+    def test_frame_introspection_attrs_are_blocked(self):
+        for attr in [
+            "gi_frame",
+            "gi_code",
+            "cr_frame",
+            "ag_frame",
+            "f_back",
+            "f_builtins",
+            "f_globals",
+            "f_locals",
+            "f_code",
+            "tb_frame",
+            "tb_next",
+            "func_globals",
+        ]:
+            with self.subTest(attr=attr):
+                self._assert_forbidden("${obj.%s}" % attr)
+
+    def test_restricted_builtins_strips_execution_primitives(self):
+        from bamboo_engine.template import sandbox as engine_sandbox
+
+        rb = engine_sandbox.restricted_builtins()
+        for name in ("eval", "exec", "compile", "open", "input", "breakpoint"):
+            self.assertNotIn(name, rb)
+        for name in ("len", "str", "range", "int", "__import__"):
+            self.assertIn(name, rb)

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -236,6 +236,26 @@ class TestMakoNameWhitelist(TestCase):
         self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
         self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
 
+    def test_existing_format_expressions_only_blocked_in_enforce(self):
+        from types import SimpleNamespace
+
+        cases = [
+            (
+                '${"gamedb.{}.xzj.db".format(set_info.bk_set_name[_loop-1])}',
+                {"set_info": SimpleNamespace(bk_set_name=["zone1"]), "_loop": 1},
+                "gamedb.zone1.xzj.db",
+            ),
+            ('${",".join(["haha{}".format(g) for g in groups])}', {"groups": ["a", "b"]}, "hahaa,hahab"),
+        ]
+        for mode in ("off", "warn", "enforce"):
+            self._set_mode(mode)
+            for template, context, expected in cases:
+                with self.subTest(mode=mode, template=template):
+                    self.assertEqual(
+                        expression.ConstantTemplate(template).resolve_data(context),
+                        template if mode == "enforce" else expected,
+                    )
+
     def test_off_mode_also_blocks_self_module(self):
         # 保留命名空间属性链下沉 always-on 后，off 模式也 inert
         # （此前 off 会解析出真实 os 模块执行命令，这里回归为拦截）。
@@ -419,8 +439,13 @@ class TestMakoSafetyHardening(TestCase):
     def test_tag_level_text_filter_is_blocked(self):
         self._assert_forbidden('<%text filter="(side_effect() or str)">x</%text>')
 
-    def test_format_attribute_call_is_blocked(self):
-        self._assert_forbidden('${"{0.__class__}".format("")}')
+    def test_format_attribute_call_is_blocked_in_enforce(self):
+        with self.assertRaises(ForbiddenMakoTemplateException):
+            check_mako_template_safety(
+                '${"{0.__class__}".format("")}',
+                mako_safety.WhitelistNameVisitor(set(), mode="enforce"),
+                mako_safety.SingleLinCodeExtractor(),
+            )
 
     def test_format_map_attribute_call_is_blocked(self):
         self._assert_forbidden('${"{value.__class__}".format_map({"value": ""})}')

--- a/runtime/bamboo-pipeline/pipeline/utils/mako_utils/checker.py
+++ b/runtime/bamboo-pipeline/pipeline/utils/mako_utils/checker.py
@@ -19,8 +19,19 @@ from mako import parsetree
 from mako.exceptions import MakoException
 from mako.lexer import Lexer
 
+from pipeline.core.data import mako_safety
+
 from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
+
+
+def validate_node_filter_callables(node: parsetree.Node):
+    # Mako stores inline `${expr | ...}` filter callables in `escapes_code`;
+    # tag-level filters use `filter_args`. Both are executed by create_filter_callable().
+    if hasattr(node, "escapes_code"):
+        mako_safety.validate_filter_args(node.escapes_code.args)
+    if hasattr(node, "filter_args"):
+        mako_safety.validate_filter_args(node.filter_args.args)
 
 
 def parse_template_nodes(
@@ -33,14 +44,15 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        code = code_extractor.extract(node)
-        if code is None:
-            continue
+        validate_node_filter_callables(node)
 
-        ast_node = ast.parse(code, "<unknown>", "exec")
-        node_visitor.visit(ast_node)
+        code = code_extractor.extract(node)
+        if code is not None:
+            ast_node = ast.parse(code, "<unknown>", "exec")
+            node_visitor.visit(ast_node)
+
         if hasattr(node, "nodes"):
-            parse_template_nodes(node.nodes, node_visitor)
+            parse_template_nodes(node.nodes, node_visitor, code_extractor)
 
 
 def check_mako_template_safety(text: str, node_visitor: ast.NodeVisitor, code_extractor: MakoNodeCodeExtractor) -> bool:

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "3.24.16"
+version = "3.24.17"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"
@@ -16,7 +16,7 @@ requests = "^2.22"
 django-celery-beat = "^2.1"
 Mako = "^1.1.4"
 pytz = ">=2019.3"
-bamboo-engine = "2.6.5"
+bamboo-engine = "2.6.6"
 jsonschema = "^2.5.1"
 ujson = "^4"
 pyparsing = "^2.2"

--- a/tests/template/test_format_mode.py
+++ b/tests/template/test_format_mode.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from bamboo_engine.config import Settings
+from bamboo_engine.template import Template
+from bamboo_engine.utils import mako_safety
+from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
+from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
+
+
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+def test_format_renders_only_outside_enforce(monkeypatch, mode):
+    monkeypatch.setattr(Settings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", mode)
+    template = "${pattern.format(name)}"
+    assert Template(template).render({"pattern": "gamedb.{}.xzj.db", "name": "zone1"}) == (
+        template if mode == "enforce" else "gamedb.zone1.xzj.db"
+    )
+
+
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+def test_format_map_and_custom_filters_stay_blocked(monkeypatch, mode):
+    monkeypatch.setattr(Settings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", mode)
+    for template in ("${pattern.format_map(values)}", "${name | custom}"):
+        assert (
+            Template(template).render({"pattern": "{name}", "values": {"name": "prod"}, "name": "prod", "custom": str})
+            == template
+        )
+
+
+@pytest.mark.parametrize("payload", ['${"{0.__class__}".format("")}', "${pattern.format}"])
+def test_enforce_blocks_format_lookup_and_method_reference(payload):
+    with pytest.raises(ForbiddenMakoTemplateException):
+        check_mako_template_safety(
+            payload,
+            mako_safety.WhitelistNameVisitor({"pattern"}, mode="enforce"),
+            mako_safety.SingleLinCodeExtractor(),
+        )

--- a/tests/template/test_mako_attr_policy.py
+++ b/tests/template/test_mako_attr_policy.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import ast
+
+from bamboo_engine.utils.mako_safety import import_chain_violation, resolve_attr_chain
+
+
+def _attr_node(expr):
+    tree = ast.parse(expr, "<t>", "eval")
+    node = tree.body
+    while isinstance(node, ast.Call):
+        node = node.func
+    assert isinstance(node, ast.Attribute)
+    return node
+
+
+def test_resolve_attr_chain_name_two_levels():
+    kind, root, attrs = resolve_attr_chain(_attr_node("json.codecs.builtins"))
+    assert kind == "name"
+    assert root == "json"
+    assert attrs == ["codecs", "builtins"]
+
+
+def test_resolve_attr_chain_stops_at_call():
+    kind, root, attrs = resolve_attr_chain(_attr_node('datetime.datetime.now().strftime("%Y")'))
+    assert kind == "call_result"
+    assert root is None
+    assert attrs == ["strftime"]
+
+
+def test_import_json_loads_ok():
+    aliases = frozenset(["json", "re", "os.path", "datetime", "datetime.datetime"])
+    assert import_chain_violation("json", ["loads"], aliases) is None
+
+
+def test_import_os_path_join_ok():
+    aliases = frozenset(["os.path", "json"])
+    assert import_chain_violation("os", ["path", "join"], aliases) is None
+
+
+def test_import_os_popen_rejected():
+    aliases = frozenset(["os.path"])
+    reason = import_chain_violation("os", ["popen"], aliases)
+    assert reason is not None
+
+
+def test_import_json_codecs_builtins_rejected():
+    aliases = frozenset(["json"])
+    reason = import_chain_violation("json", ["codecs", "builtins"], aliases)
+    assert reason is not None
+
+
+def test_import_datetime_now_needs_class_alias():
+    aliases = frozenset(["datetime"])
+    assert import_chain_violation("datetime", ["datetime", "now"], aliases) is not None
+    aliases = frozenset(["datetime", "datetime.datetime"])
+    assert import_chain_violation("datetime", ["datetime", "now"], aliases) is None
+
+
+def test_non_import_root_is_ignored():
+    aliases = frozenset(["json"])
+    assert import_chain_violation("resdata", ["_module"], aliases) is None

--- a/tests/template/test_sandbox_import.py
+++ b/tests/template/test_sandbox_import.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import datetime as dt
+
+from bamboo_engine.template.sandbox import ModuleObject, _import_modules, resolve_import_object
+
+
+def test_resolve_import_object_module():
+    import json
+
+    assert resolve_import_object("json") is json
+
+
+def test_resolve_import_object_class_path():
+    assert resolve_import_object("datetime.datetime") is dt.datetime
+
+
+def test_dotted_alias_does_not_clobber_existing_module():
+    sandbox = {}
+    _import_modules(
+        sandbox,
+        {
+            "datetime": "datetime",
+            "datetime.datetime": "datetime.datetime",
+        },
+    )
+    assert sandbox["datetime"] is dt
+    assert sandbox["datetime"].datetime is dt.datetime
+    assert sandbox["datetime"].timedelta is dt.timedelta
+    assert not isinstance(sandbox["datetime"], ModuleObject)
+
+
+def test_os_path_still_uses_module_object():
+    sandbox = {}
+    _import_modules(sandbox, {"os.path": "os.path"})
+    assert isinstance(sandbox["os"], ModuleObject)
+    assert hasattr(sandbox["os"], "path")
+    assert not hasattr(sandbox["os"], "popen")

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -13,8 +13,14 @@ specific language governing permissions and limitations under the License.
 
 import datetime
 
+import pytest
+from mako.template import Template as MakoTemplate
+
 from bamboo_engine.config import Settings
 from bamboo_engine.template import Template
+from bamboo_engine.utils import mako_safety
+from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
+from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
 def test_get_reference():
@@ -110,3 +116,214 @@ def test_mako_attack():
     ]
     for at in attack_templates:
         assert Template(at).render({}) == at
+
+
+@pytest.fixture
+def whitelist_mode():
+    original_mode = Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE
+    original_extra = Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
+    def _set(mode, extra=()):
+        Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
+        Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
+
+    try:
+        yield _set
+    finally:
+        Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = original_mode
+        Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = original_extra
+
+
+def test_mako_self_module_namespace_executes_when_whitelist_off(whitelist_mode):
+    whitelist_mode("off")
+    payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
+    rendered = Template(payload).render({})
+    assert "OFF" in rendered
+
+
+def test_mako_whitelist_default_blocks_self_module_namespace():
+    payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+    assert Template(payload).render({}) == payload
+
+
+def _assert_forbidden_template(payload):
+    with pytest.raises(ForbiddenMakoTemplateException):
+        check_mako_template_safety(
+            payload,
+            mako_safety.SingleLineNodeVisitor(),
+            mako_safety.SingleLinCodeExtractor(),
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${self.module.cache.util.os.popen("echo PWNED").read()}',
+        "${context.lookup}",
+        "${local.something}",
+        "${parent.foo}",
+        "${caller.body()}",
+        "${pageargs.x}",
+    ],
+)
+def test_mako_whitelist_blocks_reserved_namespaces(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    assert Template(payload).render({}) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${os.path.os.popen("echo PWNED").read()}',
+        '${os.path.genericpath.os.popen("echo PWNED").read()}',
+        '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+        '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+        '${os.path.os.system("echo PWNED")}',
+    ],
+)
+def test_mako_whitelist_blocks_dangerous_attr_chain(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "re": "re",
+        "os.path": "os.path",
+    }
+    try:
+        rendered = Template({"x": payload}).render({})
+        assert rendered["x"] == payload
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${context._kwargs}",
+        "${context._with_template}",
+        "${context._data}",
+        "${obj._secret}",
+        "${obj.public._private}",
+    ],
+)
+def test_mako_whitelist_blocks_single_underscore_attr(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    rendered = Template({"x": payload}).render({"obj": object()})
+    assert rendered["x"] == payload
+
+
+def test_mako_whitelist_allows_business_patterns(whitelist_mode):
+    whitelist_mode("enforce")
+    cases = [
+        ("${name.upper()}", {"name": "abc"}, "ABC"),
+        ("${name.split('-')}", {"name": "a-b-c"}, "['a', 'b', 'c']"),
+        ("${[x * 2 for x in items]}", {"items": [1, 2, 3]}, "[2, 4, 6]"),
+        ("${(lambda y: y + 1)(seed)}", {"seed": 4}, "5"),
+        ("${a if a else 'default'}", {"a": ""}, "default"),
+        ("${len(items)}", {"items": [1, 2, 3]}, "3"),
+    ]
+    for tpl, ctx, expected in cases:
+        assert Template(tpl).render(ctx) == expected
+
+
+def test_mako_whitelist_allows_imported_modules(whitelist_mode):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "os.path": "os.path",
+    }
+    try:
+        assert Template('${os.path.join("a", "b")}').render({}) == "a/b"
+        out = Template('${datetime.datetime.now().strftime("%Y")}').render({})
+        assert len(out) == 4 and out.isdigit()
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+def test_mako_whitelist_extra_names_allowed(whitelist_mode):
+    whitelist_mode("enforce", extra=("_loop", "_system"))
+    assert Template("${_loop}").render({"_loop": 7}) == 7
+    assert Template("${_loop + 1}").render({"_loop": 2}) == "3"
+
+
+def test_mako_whitelist_unknown_root_name_is_blocked(whitelist_mode):
+    whitelist_mode("enforce")
+    payload = "${secret_var}"
+    assert Template(payload).render({}) == payload
+
+
+def test_mako_filter_side_effect_expression_is_blocked():
+    _assert_forbidden_template("${'x'|((side_effect() or str))}")
+
+
+def test_mako_filter_dunder_chain_is_blocked():
+    _assert_forbidden_template("${'x'|().__class__.__bases__[0].__subclasses__}")
+
+
+def test_mako_filter_list_blocks_any_malicious_item():
+    _assert_forbidden_template("${'x'|h, (side_effect() or str)}")
+
+
+def test_mako_decode_filter_private_attribute_is_blocked():
+    _assert_forbidden_template("${'x'|decode.__class__}")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '<%page expression_filter="(side_effect() or str)"/>${name}',
+        '<%def name="render_name(name)" filter="(side_effect() or str)">${name}</%def>${render_name("x")}',
+        '<%block filter="(side_effect() or str)">x</%block>',
+        '<%text filter="(side_effect() or str)">x</%text>',
+    ],
+)
+def test_mako_tag_filter_callables_are_blocked(payload):
+    _assert_forbidden_template(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${' x ' | h}",
+        "${' x ' | trim}",
+        "${' x ' | h, trim}",
+        "${'x' | n}",
+        "${b'abc' | decode.utf8}",
+    ],
+)
+def test_mako_builtin_filters_remain_allowed(payload):
+    check_mako_template_safety(
+        payload,
+        mako_safety.SingleLineNodeVisitor(),
+        mako_safety.SingleLinCodeExtractor(),
+    )
+
+
+def test_mako_builtin_filter_rendering_still_works():
+    assert MakoTemplate("${'x' | h}").render_unicode() == "x"
+    assert MakoTemplate("${' x ' | trim}").render_unicode() == "x"
+
+
+def test_mako_filter_side_effect_is_not_executed_by_template_render():
+    sentinel = {"called": False}
+
+    def side_effect():
+        sentinel["called"] = True
+        return str
+
+    payload = "${'x'|((side_effect() or str))}"
+
+    assert Template(payload).render({"side_effect": side_effect}) == payload
+    assert sentinel["called"] is False
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${"{0.__class__}".format("")}',
+        '${"{value.__class__}".format_map({"value": ""})}',
+    ],
+)
+def test_mako_format_private_lookup_is_blocked(payload):
+    _assert_forbidden_template(payload)

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -81,7 +81,10 @@ def test_render__with_sandbox():
     r2 = Template("""${datetime.datetime.now().strftime("%Y")}""").render({})
     assert r2 == """${datetime.datetime.now().strftime("%Y")}"""
 
-    Settings.MAKO_SANDBOX_IMPORT_MODULES = {"datetime": "datetime"}
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "datetime.datetime": "datetime.datetime",
+    }
 
     r2 = Template("""${datetime.datetime.now().strftime("%Y")}""").render({})
     year = datetime.datetime.now().strftime("%Y")
@@ -196,19 +199,26 @@ def test_mako_whitelist_blocks_dangerous_attr_chain(whitelist_mode, payload):
         Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
 
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        "${context._kwargs}",
-        "${context._with_template}",
-        "${context._data}",
-        "${obj._secret}",
-        "${obj.public._private}",
-    ],
-)
-def test_mako_whitelist_blocks_single_underscore_attr(whitelist_mode, payload):
+def test_mako_whitelist_allows_user_single_underscore_attr(whitelist_mode):
     whitelist_mode("enforce")
-    rendered = Template({"x": payload}).render({"obj": object()})
+
+    class Bag(object):
+        def __init__(self):
+            self._module = [{"gamesvr": "1.1.1.1"}]
+
+    out = Template("${obj._module[0]['gamesvr']}").render({"obj": Bag()})
+    assert out == "1.1.1.1"
+
+
+def test_mako_whitelist_allows_bare_reserved_name(whitelist_mode):
+    whitelist_mode("enforce")
+    assert Template("${parent + ''}").render({"parent": "alice"}) == "alice"
+
+
+def test_mako_whitelist_blocks_self_module_even_if_self_in_context(whitelist_mode):
+    whitelist_mode("enforce")
+    payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+    rendered = Template({"x": payload}).render({"self": "ignored"})
     assert rendered["x"] == payload
 
 
@@ -231,12 +241,31 @@ def test_mako_whitelist_allows_imported_modules(whitelist_mode):
     original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
     Settings.MAKO_SANDBOX_IMPORT_MODULES = {
         "datetime": "datetime",
+        "datetime.datetime": "datetime.datetime",
         "os.path": "os.path",
+        "json": "json",
+        "hashlib": "hashlib",
     }
     try:
         assert Template('${os.path.join("a", "b")}').render({}) == "a/b"
         out = Template('${datetime.datetime.now().strftime("%Y")}').render({})
         assert len(out) == 4 and out.isdigit()
+        assert Template("${json.dumps({'a': 1})}").render({})
+        digest = Template("${hashlib.md5(b'x').hexdigest()}").render({})
+        assert len(digest) == 32
+        deep = "${json.codecs.builtins.exec('1')}"
+        assert Template({"x": deep}).render({})["x"] == deep
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+def test_mako_whitelist_datetime_now_requires_configured_class_alias(whitelist_mode):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {"datetime": "datetime"}
+    try:
+        payload = '${datetime.datetime.now().strftime("%Y")}'
+        assert Template({"x": payload}).render({})["x"] == payload
     finally:
         Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
 

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -356,3 +356,58 @@ def test_mako_filter_side_effect_is_not_executed_by_template_render():
 )
 def test_mako_format_private_lookup_is_blocked(payload):
     _assert_forbidden_template(payload)
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "gi_frame",
+        "gi_code",
+        "cr_frame",
+        "ag_frame",
+        "f_back",
+        "f_builtins",
+        "f_globals",
+        "f_locals",
+        "f_code",
+        "tb_frame",
+        "tb_next",
+        "func_globals",
+    ],
+)
+def test_mako_frame_introspection_attr_is_blocked(attr):
+    # 无论根对象是什么，通向 frame 的反射属性名一律在 always-on 的 SingleLineNodeVisitor 拒绝。
+    _assert_forbidden_template("${obj.%s}" % attr)
+
+
+def test_mako_generator_frame_builtins_gadget_is_inert_in_all_modes(whitelist_mode):
+    # 生成器帧 -> 真实 builtins -> eval 的通用 RCE：off / warn / enforce 三档都必须拦。
+    payload = (
+        "${(i for i in [1]).gi_frame.f_builtins['eval']"
+        "(\"__import__('os').popen('echo PWNED').read()\")}"
+    )
+    for mode in ("off", "warn", "enforce"):
+        whitelist_mode(mode)
+        assert Template(payload).render({}) == payload
+
+
+def test_restricted_builtins_strips_execution_primitives():
+    from bamboo_engine.template import sandbox
+
+    rb = sandbox.restricted_builtins()
+    for name in ("eval", "exec", "compile", "open", "input", "breakpoint"):
+        assert name not in rb
+    # 不能误伤 Mako codegen / 业务表达式需要的安全内建，以及 C 扩展惰性 import 依赖的 __import__。
+    for name in ("len", "str", "range", "int", "dict", "enumerate", "__import__"):
+        assert name in rb
+
+
+def test_harden_template_builtins_is_defense_in_depth(whitelist_mode, monkeypatch):
+    # 模拟未来某条未被枚举到的"通向 frame"链路：临时清空属性 deny-list，证明即便 AST 放过，
+    # 渲染期受限 builtins 也已摘掉 eval，攻击者拿不到执行原语；同时不影响安全内建（len）。
+    whitelist_mode("off")
+    monkeypatch.setattr(mako_safety, "FRAME_INTROSPECTION_ATTRS", frozenset())
+    pwn = "${(i for i in [1]).gi_frame.f_builtins['eval']('1+1')}"
+    assert Template(pwn).render({}) == pwn
+    safe = "${(i for i in [1]).gi_frame.f_builtins['len']([1, 2, 3])}"
+    assert Template(safe).render({}) == "3"

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -137,11 +137,13 @@ def whitelist_mode():
         Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = original_extra
 
 
-def test_mako_self_module_namespace_executes_when_whitelist_off(whitelist_mode):
-    whitelist_mode("off")
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+def test_mako_self_module_namespace_blocked_in_all_modes(whitelist_mode, mode):
+    # 保留命名空间属性链下沉到 always-on 层后，off / warn 也不再解析出真实模块，
+    # 经典 ``${self.module.cache.util.os...}`` 链在所有模式下都 inert。
+    whitelist_mode(mode)
     payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
-    rendered = Template(payload).render({})
-    assert "OFF" in rendered
+    assert Template(payload).render({}) == payload
 
 
 def test_mako_whitelist_default_blocks_self_module_namespace():
@@ -411,3 +413,89 @@ def test_harden_template_builtins_is_defense_in_depth(whitelist_mode, monkeypatc
     assert Template(pwn).render({}) == pwn
     safe = "${(i for i in [1]).gi_frame.f_builtins['len']([1, 2, 3])}"
     assert Template(safe).render({}) == "3"
+
+
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${os.path.os.system("echo PWNED")}',
+        '${os.path.genericpath.os.popen("echo PWNED").read()}',
+        '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+        '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+        '${json.codecs.builtins.exec("import os")}',
+    ],
+)
+def test_mako_dangerous_attr_chain_blocked_in_all_modes(whitelist_mode, mode, payload):
+    # 危险属性名下沉 always-on 后，模块反向 pivot 在 off / warn / enforce 三档都 inert，
+    # 不再依赖白名单模式（此前 off 模式可直接拿到真实 os / builtins 模块执行命令）。
+    whitelist_mode(mode)
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "re": "re",
+        "os.path": "os.path",
+        "json": "json",
+    }
+    try:
+        assert Template({"x": payload}).render({})["x"] == payload
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${context.lookup}",
+        "${local.something}",
+        "${parent.foo}",
+        "${caller.body()}",
+        "${pageargs.x}",
+    ],
+)
+def test_mako_reserved_namespace_chain_blocked_in_all_modes(whitelist_mode, mode, payload):
+    # 保留命名空间属性链（即使不以危险属性收尾）在所有模式下 inert。
+    whitelist_mode(mode)
+    assert Template(payload).render({}) == payload
+
+
+def test_filter_import_modules_rejects_dangerous_keeps_safe():
+    from bamboo_engine.template import sandbox
+
+    src = {
+        "os": "os",
+        "subprocess": "subprocess",
+        "operator": "operator",
+        "pickle": "pickle",
+        "importlib": "importlib",
+        "ctypes": "ctypes",
+        "os.path": "os.path",
+        "json": "json",
+        "re": "re",
+    }
+    safe = sandbox.filter_import_modules(src)
+    # 危险模块被拒绝；os.path（安全子模块）与普通模块保留。
+    assert set(safe) == {"os.path", "json", "re"}
+
+
+def test_sandbox_get_does_not_expose_dangerous_module():
+    from bamboo_engine.template import sandbox
+
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "os": "os",
+        "subprocess": "subprocess",
+        "os.path": "os.path",
+        "json": "json",
+    }
+    try:
+        data = sandbox.get()
+        # 直接注入的 os / subprocess 被 deny-list 拦掉，不进入渲染命名空间。
+        assert "subprocess" not in data
+        assert getattr(data.get("os"), "system", None) is None
+        # os.path 仍作为 ModuleObject 暴露 join 等安全路径操作；普通模块保留。
+        assert data.get("os") is not None and hasattr(data["os"], "path")
+        assert "json" in data
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -352,7 +352,6 @@ def test_mako_filter_side_effect_is_not_executed_by_template_render():
 @pytest.mark.parametrize(
     "payload",
     [
-        '${"{0.__class__}".format("")}',
         '${"{value.__class__}".format_map({"value": ""})}',
     ],
 )


### PR DESCRIPTION
## 背景与行为

3.24 LTS 接入按攻击原语收紧的 Mako 根标识符检查，保留 `${resdata._module}` 等单下划线数据字段和光杆保留名的合法用法。导入模块按配置 alias 验证属性链，engine 与 legacy 实现保持一致。

本次兼容性修正：`.format` 不再属于无条件检查项，只在 `MAKO_TEMPLATE_NAME_WHITELIST_MODE=enforce` 时拒绝（包括方法引用）。`off/warn` 恢复存量 `.format(...)` 渲染；`.format_map`、自定义 filter、危险属性、保留命名空间属性链、frame 内省和双下划线防护仍保持无条件拦截。检查器及模块导入策略不因本次修正放宽。

库的模式默认值仍是 `enforce`。需要存量 `.format` 兼容的接入方必须显式使用 `off/warn`；这两档也不会执行 `.format` 内部字段访问的检查，不代表与 enforce 具有相同防护强度。

## 版本与接入

- 目标分支：`bamboo_pipeline_3.24_lts`；master 对应 PR 为 #283。
- bamboo-engine 2.6.5 → 2.6.6；bamboo-pipeline 3.24.16 → 3.24.17，依赖 engine 2.6.6。
- `${datetime.datetime.now()}` 需接入方同时配置 `datetime` 与 `datetime.datetime` 别名，并同步更新依赖包。

## 验证

2026-09-07 在提交 `9861528` 上本地验证：

- engine `tests/template`：113 passed。
- legacy `test_expression` + `test_sandbox`：52 passed。
- 新增回归覆盖 off/warn/enforce、format 方法引用、format_map/filter 保持拦截，以及存量流程中 `gamedb.{}.xzj.db` 和推导式拼接两类表达式。

以上为本地库级验证，不代表生产部署或业务回归已完成。
