### PR TITLE
feat(mako): 可选子进程渲染与通信、超时及进程池加固（stack 于 #284）

### DIFF
--- a/bamboo_engine/__version__.py
+++ b/bamboo_engine/__version__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-__version__ = "2.6.5"
+__version__ = "2.6.6"

--- a/bamboo_engine/config.py
+++ b/bamboo_engine/config.py
@@ -21,6 +21,7 @@ class Settings:
 
     MAKO_SANDBOX_SHIELD_WORDS = [
         "ascii",
+        "breakpoint",
         "bytearray",
         "bytes",
         "callable",
@@ -33,6 +34,7 @@ class Settings:
         "exec",
         "eval",
         "filter",
+        "format",
         "frozenset",
         "getattr",
         "globals",
@@ -62,5 +64,17 @@ class Settings:
     ]
 
     MAKO_SANDBOX_IMPORT_MODULES = {}
+
+    # 模板根标识符白名单模式：
+    #   "off"     - 关闭白名单（兼容历史行为）
+    #   "warn"    - 仅记录违规日志，不阻断渲染（灰度阶段使用）
+    #   "enforce" - 违规即按当前 deny-list 风格拦截（行为同 ForbiddenMakoTemplateException）
+    # 默认 "enforce"，避免默认安装后继续暴露 Mako 渲染期保留命名空间注入链路。
+    # 如接入方确有兼容性风险，可在自身 settings 中临时切到 "warn" 或 "off"。
+    MAKO_TEMPLATE_NAME_WHITELIST_MODE = "enforce"
+
+    # 在白名单基础上额外允许的根标识符（除 context/导入模块/SAFE_BUILTIN_NAMES 之外）。
+    # 接入方通常用于声明 ``_system``、``_loop`` 这类 Mako 渲染期才注入的特殊对象名。
+    MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset()
 
     RERUN_INDEX_OFFSET = 0

--- a/bamboo_engine/template/render_backend.py
+++ b/bamboo_engine/template/render_backend.py
@@ -29,16 +29,34 @@ specific language governing permissions and limitations under the License.
 import atexit
 import inspect
 import logging
-import multiprocessing
+import datetime
+import decimal
+from collections import Counter
 import os
 import pickle
 import queue
 import sys
+import socket
+import signal
+import subprocess
+import time
+import uuid
+from types import SimpleNamespace
 import threading
 
 from mako.template import Template as MakoTemplate
 from mako.exceptions import MakoException
 
+from bamboo_engine.template.render_transport import (
+    MAX_REQUEST_BYTES,
+    MAX_RESPONSE_BYTES,
+    ProtocolError,
+    RenderTimeout as _RenderTimeout,
+    SocketConnection,
+    decode_reply,
+    encode_reply,
+    remaining,
+)
 from bamboo_engine.config import Settings
 from bamboo_engine.template.sandbox import harden_template_builtins
 
@@ -86,8 +104,8 @@ class InProcessRenderBackend(RenderBackend):
 class SandboxSpec(object):
     """可序列化的渲染沙箱配置，供隔离 backend 在子进程本地重建沙箱。
 
-    只携带字符串型配置（flavor + shield_words + import_modules），因此可安全跨进程 pickle；真正
-    带副作用、不可序列化的模块对象由 :meth:`build` 在目标进程本地重建。
+    仅向 worker 发送受信任的字符串配置（flavor + shield_words + import_modules）；
+    模块对象由 :meth:`build` 在目标进程本地重建。不得从 worker 接收此对象的 pickle。
 
     * ``engine`` flavor → ``bamboo_engine.template.sandbox.build_sandbox``（无 mock builtins）
     * ``legacy`` flavor → ``pipeline.core.data.sandbox_builder.build_sandbox``（含 mock builtins，
@@ -146,36 +164,20 @@ class SandboxProvider(object):
         return self._spec
 
 
-# --------------------------------------------------------------------------------------------------
-# 隔离渲染后端：无网无凭证的 spawn worker 进程池
-#
-# 设计依据：docs/specs/2026-09-04-mako-render-isolation-design.md。核心不变量——
-#   * 渲染面（唯一执行用户表达式处）搬进独立子进程；子进程 **无凭证**（启动即清洗 env）、
-#     后续可叠加 **无网络**（OS 加固钩子，Linux 生效）。即便渲染被 RCE 打穿，也拿不到全局
-#     密钥、连不出网络，无法把标准运维当跳板打生态。
-#   * worker 用 ``spawn`` 全新解释器，不 import Django / 业务 app / 凭证；沙箱由父进程序列化过来的
-#     ``SandboxSpec`` 在 worker 本地重建（engine / legacy 两种 flavor 都已 Django-free）。
-#   * warm 池复用（避免每次渲染新开进程），``max_uses`` 用后回收，每次渲染都以全新沙箱重建
-#     （pristine），杜绝跨执行状态泄漏。
-#   * 失败兜底 fail-safe：不可序列化 context / worker 异常 → 回退进程内渲染；渲染超时 → inert
-#     回显原始模板（**不**回退进程内，避免把 DoS 带回主进程）。
-# --------------------------------------------------------------------------------------------------
+# The subprocess backend reduces exposure but is not a filesystem/credential sandbox.
+# Workers start with an environment allowlist and close unrelated descriptors. When
+# no_network=True they MUST establish a network namespace before reading requests.
+# Context and sandbox configuration are trusted host inputs (one-way pickle); replies
+# from the potentially compromised worker are bounded JSON, never executable pickle.
 
-# --------------------------------------------------------------------------------------------------
-# 可移植 context 归一化
-#
-# 无 Django 的最小 worker 只能 unpickle「builtin/stdlib 类型 + 本模块自带的类」。而 bk-sops 的 rich 内置
-# 变量（DataTableValue / SetGroupInfo / SetInfo / SetModuleInfo / SetDetailData）返回的对象虽只含 plain
-# data、父进程可 pickle，但其**类定义模块 import 即依赖 Django**，worker 侧 unpickle 会失败。
-#
-# 这些 rich 对象都是「属性包」：__init__ 里 eager ``setattr`` 把数据落进 ``__dict__``，只实现 ``__repr__``，
-# 模板用法就是属性访问 + 列表下标 + bare ``${var}``（取字符串）。因此在 pickle 前把它们忠实搬运成
-# Django-free 的 :class:`PortableRenderObject`（属性 + str/repr），即可让含 rich 变量的模板也进隔离渲染，
-# 而不是被迫回退进程内。只在隔离 backend 的发送路径做，进程内渲染仍见原对象、行为零变化。
-# --------------------------------------------------------------------------------------------------
+
+class UnsupportedContext(ValueError):
+    """Context cannot be transported without changing its template-visible behavior."""
+
 
 _PORTABLE_SCALAR_TYPES = (str, bytes, bytearray, bool, int, float, complex, type(None))
 _PORTABLE_MAX_DEPTH = 8
+_PORTABLE_MAX_ITEMS = 100000
 
 
 class PortableRenderObject(object):
@@ -202,53 +204,70 @@ class PortableRenderObject(object):
         return self._portable_repr
 
 
-def _safe_text(value, fn):
-    try:
-        return fn(value)
-    except Exception:  # pragma: no cover - repr/str 抛错兜底
-        return "<unrepresentable>"
+def _portable_value(value, depth, seen, budget):
+    budget[0] -= 1
+    if budget[0] < 0 or budget[1] < 0:
+        raise UnsupportedContext("render context exceeds transport budget")
+    kind = type(value)
+    if kind in (str, bytes, bytearray):
+        budget[1] -= len(value)
+        if budget[1] < 0:
+            raise UnsupportedContext("render context exceeds transport budget")
+    if kind is int and value.bit_length() > 4096:
+        raise UnsupportedContext("render context integer exceeds transport budget")
+    if kind in _PORTABLE_SCALAR_TYPES:
+        return value
+    if depth >= _PORTABLE_MAX_DEPTH or id(value) in seen:
+        raise UnsupportedContext("cyclic or excessively deep render context")
+    seen = seen | {id(value)}
 
+    def convert(item):
+        return _portable_value(item, depth + 1, seen, budget)
 
-def _portable_value(value, depth, seen):
-    # 标量：原样保留。
-    if isinstance(value, _PORTABLE_SCALAR_TYPES):
+    if kind in (dict, Counter):
+        return kind({convert(k): convert(v) for k, v in value.items()})
+    if kind in (list, tuple, set, frozenset):
+        return kind(convert(v) for v in value)
+    if kind in (time.struct_time, datetime.date, datetime.timedelta, decimal.Decimal):
         return value
-    # 可调用 / 类型 / 模块：pickle 按引用处理（stdlib/可 import 者 worker 侧可重建）；不能归一化，
-    # 否则会把函数变成不可调用的载体，破坏 ``${f()}``。
-    if callable(value) or isinstance(value, type) or inspect.ismodule(value):
+    if kind in (datetime.datetime, datetime.time):
+        if value.tzinfo is None or type(value.tzinfo) is datetime.timezone:
+            return value
+        raise UnsupportedContext("unsupported timezone type")
+    # Host-provided importable callables retain their identity. They are trusted
+    # configuration, never supplied by the worker; imports may load application code.
+    if inspect.isfunction(value) or inspect.isbuiltin(value):
         return value
-    if depth >= _PORTABLE_MAX_DEPTH:
-        return value
-    # 容器：递归归一化元素。
-    if isinstance(value, dict):
-        return {k: _portable_value(v, depth + 1, seen) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_portable_value(v, depth + 1, seen) for v in value]
-    if isinstance(value, tuple):
-        return tuple(_portable_value(v, depth + 1, seen) for v in value)
-    if isinstance(value, (set, frozenset)):
-        return type(value)(_portable_value(v, depth + 1, seen) for v in value)
-    # 属性包对象（有 ``__dict__``）：转成 PortableRenderObject；防环。
-    obj_dict = getattr(value, "__dict__", None)
-    if isinstance(obj_dict, dict):
-        vid = id(value)
-        if vid in seen:  # 环：只保留字符串形态、断链。
-            return PortableRenderObject({}, _safe_text(value, str), _safe_text(value, repr))
-        seen = seen | {vid}
-        attrs = {k: _portable_value(v, depth + 1, seen) for k, v in obj_dict.items()}
-        return PortableRenderObject(attrs, _safe_text(value, str), _safe_text(value, repr))
-    # 其它（无 ``__dict__``、非标量/容器/可调用，如 datetime/Decimal/lock）：原样保留，交给
-    # pickle / worker 决定——stdlib 可移植者正常重建，真不可序列化者由发送路径统一兜底。
-    return value
+    # Only structural attribute bags are converted. Properties, methods, inherited
+    # behavior and container subclasses must take the explicit unsupported path.
+    bag_members = {
+        "__module__",
+        "__doc__",
+        "__dict__",
+        "__weakref__",
+        "__init__",
+        "__repr__",
+        "__str__",
+        "__getstate__",
+        "__setstate__",
+    }
+    is_bag = kind in (PortableRenderObject, SimpleNamespace) or (
+        kind.__bases__ == (object,) and set(vars(kind)).issubset(bag_members)
+    )
+    if is_bag and type(getattr(value, "__dict__", None)) is dict:
+        attrs = {k: convert(v) for k, v in vars(value).items()}
+        return PortableRenderObject(attrs, str(value), repr(value))
+    raise UnsupportedContext("unsupported render context type: {}.{}".format(kind.__module__, kind.__name__))
 
 
 def _portable_context(context):
-    """把渲染 context 归一化为「仅含 builtin/stdlib 类型 + PortableRenderObject」的可移植结构。
+    """Validate supported host values before one-way transport; never coerce unknown behavior.
 
-    仅供隔离 backend 在 pickle 前调用；进程内渲染不经过它、行为完全不变。
+    Importable host functions remain trusted references. Inprocess bypasses conversion.
     """
-    seen = frozenset()
-    return {k: _portable_value(v, 0, seen) for k, v in context.items()}
+    if type(context) is not dict or any(type(k) is not str for k in context):
+        raise UnsupportedContext("render context must have plain string keys")
+    return _portable_value(context, 0, frozenset(), [_PORTABLE_MAX_ITEMS, MAX_REQUEST_BYTES])
 
 
 _STATUS_OK = 0
@@ -284,31 +303,16 @@ DEFAULT_ENV_SCRUB_PATTERNS = (
 DEFAULT_OS_HARDEN_RLIMIT_CPU = 30  # 秒；CPU 时间硬上限，作为 wall-clock timeout 的兜底，杀死 ${9**9**9} 这类狂算
 DEFAULT_OS_HARDEN_RLIMIT_AS_MB = 1024  # MB；地址空间上限，抑制渲染面内存炸弹
 
-# 测试注入用的 OS 加固覆盖钩子。默认 None；置为可调用对象时，:func:`_apply_os_hardening` 优先执行它。
-# 注意：``spawn`` worker 会以全新解释器重新 import 本模块，故该覆盖只在**同进程**内生效（单测用），
-# 真实 worker 的加固由 :func:`_apply_os_hardening` 依据传入的 ``opts`` 在子进程本地施加。
-_OS_HARDENING_HOOK = None
-
 
 def _try_unshare_network():
-    """尽力把 worker 放进独立的空网络 namespace（Linux）。
+    """Fail closed if the explicitly requested network namespace is unavailable."""
+    if not sys.platform.startswith("linux"):
+        raise RuntimeError("network isolation requires Linux")
+    import ctypes
 
-    需要 CAP_SYS_ADMIN / user namespace，普通部署常无权限而失败（EPERM）——此时仅 debug 记录并继续：
-    **凭证已被 env-scrub 清除**，即便有网也无法冒充平台身份，这是纵深防御而非唯一屏障。
-    """
-    try:
-        import ctypes
-
-        libc = ctypes.CDLL("libc.so.6", use_errno=True)
-        clone_newnet = 0x40000000  # CLONE_NEWNET
-        if libc.unshare(clone_newnet) != 0:
-            err = ctypes.get_errno()
-            logger.debug(
-                "mako render worker unshare(CLONE_NEWNET) failed errno=%s (need userns/root); env already scrubbed",
-                err,
-            )
-    except Exception as e:  # pragma: no cover - 平台/权限差异
-        logger.debug("mako render worker network unshare unavailable: %s", e)
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    if libc.unshare(0x40000000) != 0:  # CLONE_NEWNET
+        raise RuntimeError("network isolation failed errno={}".format(ctypes.get_errno()))
 
 
 def _scrub_environ(patterns):
@@ -323,161 +327,205 @@ def _scrub_environ(patterns):
 
 
 def _apply_os_hardening(opts):
-    """在 worker 本地施加 OS 级加固（rlimits + 尽力无网）。Linux 生效，其它平台 no-op。
-
-    ``opts`` 为可跨进程序列化的 dict：``{"enabled", "no_network", "rlimit_cpu", "rlimit_as_mb"}``。
-    任何异常都不得打断渲染——加固失败时以 fail-open 记录日志继续（env-scrub 仍已生效）。
-    单测可通过设置模块级 ``_OS_HARDENING_HOOK`` 覆盖真实逻辑。
-    """
-    # 测试覆盖优先（仅同进程生效）。
-    if _OS_HARDENING_HOOK is not None:
-        try:
-            _OS_HARDENING_HOOK()
-        except Exception as e:  # pragma: no cover - defensive
-            logger.warning("mako render worker os-hardening hook failed: %s", e)
+    """Requested network isolation must succeed; resource limits apply on Linux."""
+    if not opts:
         return
-    if not opts or not opts.get("enabled"):
-        return
-    if not sys.platform.startswith("linux"):
-        return  # macOS / 其它平台：加固不可用，no-op（隔离仍靠 spawn + env-scrub）
-
-    try:
-        import resource
-
-        def _set_rlimit(res, soft):
-            try:
-                cur_soft, hard = resource.getrlimit(res)
-                new_soft = soft if hard == resource.RLIM_INFINITY else min(soft, hard)
-                resource.setrlimit(res, (new_soft, hard))
-            except Exception as e:  # pragma: no cover - 平台差异
-                logger.debug("mako render worker setrlimit(%s) failed: %s", res, e)
-
-        # 禁 core dump：避免带凭证/context 的内存随 core 落盘。
-        _set_rlimit(resource.RLIMIT_CORE, 0)
-        cpu = opts.get("rlimit_cpu")
-        if cpu:
-            _set_rlimit(resource.RLIMIT_CPU, int(cpu))
-        as_mb = opts.get("rlimit_as_mb")
-        if as_mb:
-            _set_rlimit(resource.RLIMIT_AS, int(as_mb) * 1024 * 1024)
-    except Exception as e:  # pragma: no cover - defensive, never break rendering
-        logger.warning("mako render worker rlimit hardening failed: %s", e)
-
     if opts.get("no_network"):
         _try_unshare_network()
+    if not opts.get("enabled") or not sys.platform.startswith("linux"):
+        return
+    import resource
+
+    def set_limit(res, soft):
+        _, hard = resource.getrlimit(res)
+        limit = soft if hard == resource.RLIM_INFINITY else min(soft, hard)
+        resource.setrlimit(res, (limit, limit))
+
+    set_limit(resource.RLIMIT_CORE, 0)
+    if opts.get("rlimit_cpu"):
+        set_limit(resource.RLIMIT_CPU, int(opts["rlimit_cpu"]))
+    if opts.get("rlimit_as_mb"):
+        set_limit(resource.RLIMIT_AS, int(opts["rlimit_as_mb"]) * 1024 * 1024)
 
 
 def _worker_main(conn, scrub_patterns, harden_opts):
-    """隔离 worker 主循环（``spawn`` 目标，模块级函数）。
-
-    启动即清洗凭证 env + 应用 OS 加固；随后循环处理请求：每条请求本地重建沙箱（pristine）后渲染，
-    回送 ``(status, result)``。收到 ``None`` 或管道 EOF 时退出。
-    """
-    _scrub_environ(scrub_patterns)
-    _apply_os_hardening(harden_opts)
-    while True:
-        try:
-            payload = conn.recv_bytes()
-        except EOFError:
-            break
-        try:
-            request = pickle.loads(payload)
-        except Exception as e:
-            # worker 侧反序列化失败：父进程 pickle 成功、但 worker 无法 loads——典型如 rich 内置变量
-            # （DataTableValue / SetGroupInfo 等）的类定义模块在无 Django worker 里 import 失败。
-            # 必须**立即回 STATUS_ERR** 让父进程走统一兜底（回退进程内 / strict），否则父进程只能等满
-            # timeout 再 inert，既慢又破坏正常渲染。回复不依赖请求内容，可无条件发送。
-            try:
-                conn.send_bytes(pickle.dumps((_STATUS_ERR, "unpickle request failed: {!r}".format(e))))
-            except Exception:  # pragma: no cover - 管道断裂
-                break
-            continue
-        if request is None:  # stop sentinel
-            break
-        template, context, spec = request
-        try:
-            sandbox_dict = spec.build()
-            result = _render_with_sandbox(template, context, sandbox_dict)
-            reply = pickle.dumps((_STATUS_OK, result))
-        except Exception as e:  # 沙箱重建 / 结果序列化异常 → 让父进程回退进程内
-            reply = pickle.dumps((_STATUS_ERR, repr(e)))
-        try:
-            conn.send_bytes(reply)
-        except Exception:  # pragma: no cover - 管道断裂
-            break
+    """Read trusted host requests only after all required isolation is established."""
     try:
-        conn.close()
-    except Exception:  # pragma: no cover
+        if sys.platform.startswith("linux"):
+            import ctypes
+
+            libc = ctypes.CDLL("libc.so.6", use_errno=True)
+            if libc.prctl(1, signal.SIGKILL, 0, 0, 0) != 0:  # PR_SET_PDEATHSIG
+                raise RuntimeError("cannot set render worker parent-death signal")
+            if os.getppid() != harden_opts["parent_pid"]:
+                return  # host died between exec and prctl
+        _scrub_environ(scrub_patterns)
+        _apply_os_hardening(harden_opts)
+        conn.send_bytes(b"READY", max_bytes=128)
+        while True:
+            payload = conn.recv_bytes(max_bytes=MAX_REQUEST_BYTES)
+            request_id = payload[:32].decode("ascii")
+            if len(request_id) != 32 or any(c not in "0123456789abcdef" for c in request_id):
+                raise ProtocolError("invalid request identifier")
+            try:
+                template, context, spec = pickle.loads(payload[32:])
+                result = _render_with_sandbox(template, context, spec.build())
+                reply = encode_reply(_STATUS_OK, result, request_id)
+            except Exception:
+                # Do not echo exception/context data or let a worker demand privileged fallback.
+                reply = encode_reply(_STATUS_ERR, "isolated render failed", request_id)
+            conn.send_bytes(reply, max_bytes=MAX_RESPONSE_BYTES)
+    except (EOFError, OSError, ValueError, RuntimeError):
         pass
+    finally:
+        conn.close()
 
 
-class _RenderTimeout(Exception):
-    """单次隔离渲染超时。"""
+def _worker_environment(patterns):
+    # An allowlist is applied BEFORE starting Python/site imports. Arbitrary env keys
+    # (including names without SECRET/TOKEN) must not reach the interpreter.
+    allowed = {"PATH", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "SYSTEMROOT"}
+    patterns = [p.lower() for p in patterns]
+    return {k: v for k, v in os.environ.items() if k in allowed and not any(p in k.lower() for p in patterns)}
+
+
+_CONNECTION_PID = os.getpid()
+_WORKER_SOCKETS = set()
+
+
+def _close_inherited_connections():
+    """Include transports still inside a concurrent Popen constructor during fork."""
+    global _CONNECTION_PID, _WORKER_SOCKETS
+    if _CONNECTION_PID != os.getpid():
+        inherited = tuple(_WORKER_SOCKETS)
+        _CONNECTION_PID = os.getpid()
+        _WORKER_SOCKETS = set()
+        for sock in inherited:
+            sock.close()  # local fd copy only; never shutdown the parent's socket
 
 
 class _RenderWorker(object):
-    """一个 warm 渲染子进程 + 父进程侧管道句柄 + 使用计数。"""
+    """A fresh Python interpreter, also launchable from a daemon prefork host."""
 
-    def __init__(self, ctx, scrub_patterns, harden_opts):
-        parent_conn, child_conn = ctx.Pipe(duplex=True)
-        self._conn = parent_conn
-        self._proc = ctx.Process(
-            target=_worker_main,
-            args=(child_conn, list(scrub_patterns), dict(harden_opts or {})),
-            daemon=True,
-        )
-        self._proc.start()
-        child_conn.close()  # 父进程侧关闭子端句柄，仅保留 parent_conn
+    def __init__(self, scrub_patterns, harden_opts):
+        if os.name != "posix":
+            raise RuntimeError("subprocess rendering requires POSIX")
+        _close_inherited_connections()
+        parent_sock, child_sock = socket.socketpair()
+        _WORKER_SOCKETS.update((parent_sock, child_sock))
+        self._conn = SocketConnection(parent_sock)
+        self._owner_pid = os.getpid()
         self.uses = 0
+        self._ready = False
+        self._killed = False
+        # -S avoids site hooks before hardening; no re-import of the host __main__.
+        # sys.path is trusted host configuration and carries the installed engine/runtime.
+        code = (
+            "import sys,socket; sys.path={paths!r}; "
+            "from bamboo_engine.template.render_backend import _worker_main; "
+            "from bamboo_engine.template.render_transport import SocketConnection; "
+            "_worker_main(SocketConnection(socket.socket(fileno={fd})), {scrub!r}, {opts!r})"
+        ).format(
+            paths=[os.path.abspath(p) for p in sys.path],
+            fd=child_sock.fileno(),
+            scrub=list(scrub_patterns),
+            opts=harden_opts,
+        )
+        try:
+            self._proc = subprocess.Popen(
+                [sys.executable, "-I", "-S", "-c", code],
+                pass_fds=(child_sock.fileno(),),
+                close_fds=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=_worker_environment(scrub_patterns),
+                start_new_session=True,
+            )
+        except BaseException:
+            parent_sock.close()
+            _WORKER_SOCKETS.discard(parent_sock)
+            raise
+        finally:
+            child_sock.close()
+            _WORKER_SOCKETS.discard(child_sock)
 
     @property
     def pid(self):
         return self._proc.pid
 
     def request(self, payload, timeout):
-        """发送已序列化请求，最多等 ``timeout`` 秒。超时抛 :class:`_RenderTimeout`。"""
-        self._conn.send_bytes(payload)
-        if not self._conn.poll(timeout):
-            raise _RenderTimeout()
-        resp = self._conn.recv_bytes()
+        deadline = time.monotonic() + timeout
+        if not getattr(self, "_ready", True):
+            if self._conn.recv_bytes(deadline=deadline, max_bytes=128) != b"READY":
+                raise ProtocolError("render worker isolation setup failed")
+            self._ready = True
+        request_id = uuid.uuid4().hex
+        self._conn.send_bytes(request_id.encode("ascii") + payload, deadline=deadline)
+        response = self._conn.recv_bytes(deadline=deadline, max_bytes=MAX_RESPONSE_BYTES)
+        result = decode_reply(response, request_id)
+        remaining(deadline)
         self.uses += 1
-        return pickle.loads(resp)
+        return result
 
     def is_alive(self):
-        return self._proc.is_alive()
-
-    def stop(self):
-        """优雅停止：发 sentinel + join；必要时 terminate。"""
-        try:
-            self._conn.send_bytes(pickle.dumps(None))
-        except Exception:
-            pass
-        try:
-            self._conn.close()
-        except Exception:
-            pass
-        self._proc.join(timeout=1)
-        if self._proc.is_alive():  # pragma: no cover - 兜底
-            self._proc.terminate()
-            self._proc.join(timeout=1)
+        return self._owner_pid == os.getpid() and self._proc.poll() is None
 
     def kill(self):
-        """强制回收（用于超时 / broken worker）。"""
-        try:
-            self._conn.close()
-        except Exception:
-            pass
-        if self._proc.is_alive():
-            self._proc.terminate()
-        self._proc.join(timeout=1)
+        # No blocking wait/send on the caller's deadline path.
+        self._conn.close()
+        _WORKER_SOCKETS.discard(self._conn.sock)
+        if self._owner_pid == os.getpid() and not self._killed:
+            self._killed = True
+            try:
+                os.killpg(self._proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    def stop(self):
+        self.kill()
+        if self._owner_pid == os.getpid():
+            try:
+                self._proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                return False
+        return True
+
+
+class _RenderSlot:
+    """A slot stays occupied until even a timed-out launcher has cleaned up."""
+
+    def __init__(self):
+        self.worker = None
+        self.jobs = queue.Queue()
+        self.thread = None
+        self.lock = threading.Lock()
+        self.active = None
+
+
+class _RenderJob:
+    def __init__(self, slot, deadline):
+        self.slot = slot
+        self.deadline = deadline
+        self.cancelled = threading.Event()
+        self.done = threading.Event()
+        self.result = None
+        self.error = None
+
+    def cancel(self):
+        with self.slot.lock:
+            self.cancelled.set()
+            worker = self.slot.worker
+            if self.slot.active is self and worker is not None:
+                worker.kill()
 
 
 class SubprocessPoolRenderBackend(RenderBackend):
-    """无网无凭证的 spawn worker 进程池渲染后端。
+    """Bounded warm subprocess pool; disabled by default, strict failure policy.
 
-    池不变量：``_idle`` 队列中始终维持 ``pool_size`` 个可用 worker——每次渲染 ``acquire`` 恰好取出
-    一个、结束后 ``release``/``discard`` 恰好放回一个（健康则复用，超 ``max_uses`` 或损坏则替换为
-    新 worker）。懒启动：构造时不 spawn，首次 ``render`` 才拉起池，避免 import 期 fork。
+    At most pool_size supervisor threads can exist, including launchers which outlive
+    a timeout. A slot is returned only after cleanup, so process-launch stalls cannot
+    create an unbounded number of background launchers. Later calls time out on admission.
     """
 
     def __init__(
@@ -496,10 +544,8 @@ class SubprocessPoolRenderBackend(RenderBackend):
         self.pool_size = int(pool_size or getattr(Settings, "MAKO_RENDER_POOL_SIZE", 4) or 4)
         self.max_uses = int(max_uses or getattr(Settings, "MAKO_RENDER_MAX_USES", 500) or 500)
         self.timeout = float(timeout or getattr(Settings, "MAKO_RENDER_TIMEOUT", 30) or 30)
-        # 兜底策略：默认 **strict**（无法隔离渲染即 inert 回显，不静默回退特权进程）。归一化已让绝大多数
-        # 合法 context（含 rich 内置变量）可进隔离渲染，故残余「不可序列化」多为异常/攻击者构造——此时
-        # strict 更安全，避免「加个 rich 变量 / 塞个不可序列化对象」把注入拽回有网有凭证的主进程。
-        # 灰度需要保可用时，可显式置 ``fallback_inprocess=True`` 或 ``MAKO_RENDER_FALLBACK_INPROCESS=True``。
+        # 默认 strict：未知 context 不隐式进入宿主。显式兼容回退仅处理父侧类型/spec 问题，
+        # worker、协议、启动、超时和网络隔离失败不会触发回退。
         if fallback_inprocess is None:
             fallback_inprocess = bool(getattr(Settings, "MAKO_RENDER_FALLBACK_INPROCESS", False))
         self.fallback_inprocess = fallback_inprocess
@@ -508,7 +554,7 @@ class SubprocessPoolRenderBackend(RenderBackend):
                 getattr(Settings, "MAKO_RENDER_ENV_SCRUB_EXTRA", []) or []
             )
         self._scrub_patterns = list(env_scrub_patterns)
-        # OS 级加固参数（Linux 生效）。默认开启：core dump 关闭 + CPU/内存 rlimits + 尽力无网。
+        # Linux 资源限制；no_network 为独立强制要求，不支持/无权限时拒绝渲染。
         if os_harden is None:
             os_harden = bool(getattr(Settings, "MAKO_RENDER_OS_HARDEN", True))
         if no_network is None:
@@ -523,63 +569,162 @@ class SubprocessPoolRenderBackend(RenderBackend):
             if rlimit_as_mb is not None
             else getattr(Settings, "MAKO_RENDER_RLIMIT_AS_MB", DEFAULT_OS_HARDEN_RLIMIT_AS_MB),
         }
-        self._ctx = multiprocessing.get_context(mp_context)
+        if mp_context != "spawn":
+            raise ValueError("only fresh-interpreter rendering is supported")
+        if self.pool_size <= 0 or self.max_uses <= 0 or self.timeout <= 0:
+            raise ValueError("pool size, max uses and timeout must be positive")
+        self._owner_pid = os.getpid()
         self._idle = queue.Queue()
+        self._slots = [_RenderSlot() for _ in range(self.pool_size)]
+        for slot in self._slots:
+            self._idle.put(slot)
+        self._jobs = set()
         self._inprocess = InProcessRenderBackend()
         self._lock = threading.Lock()
-        self._started = False
+        atexit.register(self.close)
         self._closed = False
 
-    # -- 池生命周期 --
+    def _ensure_process(self):
+        _close_inherited_connections()
+        if self._owner_pid == os.getpid():
+            return
+        # Forked hosts must never share transports/locks or terminate the parent's workers.
+        for slot in self._slots:
+            if slot.worker is not None:
+                slot.worker._conn.close()
+        self._owner_pid = os.getpid()
+        self._lock = threading.Lock()
+        self._idle = queue.Queue()
+        self._slots = [_RenderSlot() for _ in range(self.pool_size)]
+        for slot in self._slots:
+            self._idle.put(slot)
+        self._jobs = set()
 
     def _spawn_worker(self):
-        return _RenderWorker(self._ctx, self._scrub_patterns, self._harden_opts)
+        opts = dict(self._harden_opts, parent_pid=os.getpid())
+        return _RenderWorker(self._scrub_patterns, opts)
 
-    def _ensure_started(self):
-        if self._started:
-            return
-        with self._lock:
-            if self._started:
+    def _slot_loop(self, slot):
+        # Keep the launching thread alive for the worker's lifetime: Linux
+        # PR_SET_PDEATHSIG follows that thread, not just the host process PID.
+        while True:
+            args = slot.jobs.get()
+            if args is None:
+                if slot.worker is not None:
+                    self._retire(slot.worker)
+                    slot.worker = None
                 return
-            for _ in range(self.pool_size):
-                self._idle.put(self._spawn_worker())
-            self._started = True
-            atexit.register(self.close)
+            self._run(*args)
+            if self._closed:
+                return
 
-    def _acquire(self):
-        return self._idle.get()
+    @staticmethod
+    def _retire(worker):
+        # Only supervisor threads wait here. Even after a timeout/cleanup exception,
+        # retain the slot until the child has actually been reaped.
+        reported = False
+        while True:
+            try:
+                if worker.stop():
+                    return
+            except Exception:
+                if not reported:
+                    logger.exception("isolated render worker cleanup failed; retaining slot")
+                    reported = True
+            time.sleep(0.05)
 
-    def _release(self, worker):
-        """归还一个 worker：健康且未超 ``max_uses`` 则复用，否则停掉并补一个新 worker。"""
-        if self._closed:
-            worker.stop()
-            return
-        if worker.is_alive() and worker.uses < self.max_uses:
-            self._idle.put(worker)
-        else:
-            worker.stop()
-            self._idle.put(self._spawn_worker())
-
-    def _discard(self, worker):
-        """丢弃一个损坏 / 超时 worker，并补一个新 worker 维持池容量。"""
-        worker.kill()
-        if not self._closed:
-            self._idle.put(self._spawn_worker())
+    def _run(self, job, template, context, sandbox_builder):
+        slot = job.slot
+        try:
+            remaining(job.deadline)
+            spec = sandbox_builder.spec() if hasattr(sandbox_builder, "spec") else None
+            if type(spec) is not SandboxSpec:
+                raise UnsupportedContext("sandbox provider has no transport spec")
+            if (
+                type(template) is not str
+                or type(spec.flavor) is not str
+                or spec.flavor not in ("engine", "legacy")
+                or type(spec.shield_words) is not list
+                or any(type(w) is not str for w in spec.shield_words)
+                or type(spec.import_modules) is not dict
+                or any(type(k) is not str or type(v) is not str for k, v in spec.import_modules.items())
+            ):
+                raise UnsupportedContext("invalid render template or sandbox spec")
+            try:
+                payload = pickle.dumps((template, _portable_context(context), spec))
+            except Exception as exc:
+                raise UnsupportedContext("context cannot be transported: {}".format(type(exc).__name__)) from exc
+            if len(payload) > MAX_REQUEST_BYTES:
+                raise ProtocolError("render request too large")
+            remaining(job.deadline)
+            if job.cancelled.is_set():
+                raise _RenderTimeout()
+            if slot.worker is None or not slot.worker.is_alive():
+                if slot.worker is not None:
+                    self._retire(slot.worker)
+                slot.worker = self._spawn_worker()
+            if job.cancelled.is_set():
+                raise _RenderTimeout()
+            status, result = slot.worker.request(payload, remaining(job.deadline))
+            remaining(job.deadline)
+            if status != _STATUS_OK:
+                raise ProtocolError("isolated worker rejected render")
+            job.result = result
+        except BaseException as exc:
+            job.error = exc
+        finally:
+            # Publish the completed result before recycling. Cleanup/spawn failures
+            # cannot overwrite success; replacement is lazy on the next admitted job.
+            job.done.set()
+            try:
+                if slot.worker is not None and (
+                    job.error is not None
+                    or job.cancelled.is_set()
+                    or self._closed
+                    or slot.worker.uses >= self.max_uses
+                    or not slot.worker.is_alive()
+                ):
+                    try:
+                        self._retire(slot.worker)
+                    finally:
+                        slot.worker = None
+            except Exception:
+                logger.warning("isolated render worker cleanup failed")
+            finally:
+                retired = None
+                with self._lock:
+                    self._jobs.discard(job)
+                    with slot.lock:
+                        slot.active = None
+                    # close() and returning the slot are atomic with respect to each other.
+                    if self._closed:
+                        retired, slot.worker = slot.worker, None
+                    else:
+                        self._idle.put(slot)
+                if retired is not None:
+                    self._retire(retired)
 
     def close(self):
-        """停掉池内所有空闲 worker（幂等）。在飞的渲染完成后其 worker 也会被 stop。"""
+        self._ensure_process()
         with self._lock:
             if self._closed:
                 return
             self._closed = True
-        while True:
-            try:
-                worker = self._idle.get_nowait()
-            except queue.Empty:
-                break
-            worker.stop()
-
-    # -- 渲染 --
+            jobs = list(self._jobs)
+            while True:
+                try:
+                    self._idle.get_nowait()
+                except queue.Empty:
+                    break
+        for job in jobs:
+            job.cancel()
+            job.done.set()
+        # Include slots between Queue.get and registration in _jobs.
+        for slot in self._slots:
+            slot.jobs.put(None)
+            worker = slot.worker
+            if worker is not None:
+                worker.kill()
 
     def _fallback(self, template, context, sandbox_builder):
         if self.fallback_inprocess:
@@ -587,43 +732,80 @@ class SubprocessPoolRenderBackend(RenderBackend):
         return template
 
     def render(self, template, context, sandbox_builder):
-        spec = sandbox_builder.spec() if hasattr(sandbox_builder, "spec") else None
-        if spec is None:
-            # 拿不到可序列化 spec（历史裸 builder）→ 无法隔离 → 进程内渲染，保持向后兼容。
-            return self._inprocess.render(template, context, sandbox_builder)
+        self._ensure_process()
+        deadline = time.monotonic() + self.timeout
+        if self._closed:
+            return template
         try:
-            # 归一化 rich context 对象为 Django-free 载体，让含 rich 变量的模板也能进隔离渲染；随后整体
-            # 预序列化，在**不污染管道**的前提下探测残余不可 pickle 的 context，命中即按策略兜底。
-            payload = pickle.dumps((template, _portable_context(context), spec))
-        except Exception as e:
-            logger.warning(
-                "render context not serializable, fallback(%s): %s",
-                "inprocess" if self.fallback_inprocess else "strict-inert",
-                e,
-            )
-            return self._fallback(template, context, sandbox_builder)
-
-        self._ensure_started()
-        worker = self._acquire()
-        try:
-            status, result = worker.request(payload, self.timeout)
+            while True:
+                if self._closed:
+                    return template
+                try:
+                    slot = self._idle.get(timeout=min(0.05, remaining(deadline)))
+                    break
+                except queue.Empty:
+                    continue
         except _RenderTimeout:
-            logger.warning("isolated render timeout(%ss), inert: %s", self.timeout, template)
-            self._discard(worker)
-            return template  # 超时 inert；绝不回退进程内，避免把 DoS 带回主进程
-        except Exception as e:
-            logger.warning("isolated render worker error, fallback in-process: %s", e)
-            self._discard(worker)
-            return self._fallback(template, context, sandbox_builder)
-        else:
-            self._release(worker)
-            if status == _STATUS_OK:
-                return result
-            logger.warning("isolated render sandbox error(%s), fallback in-process", result)
-            return self._fallback(template, context, sandbox_builder)
+            logger.warning("isolated render admission timeout")
+            return template
+        job = _RenderJob(slot, deadline)
+        with self._lock:
+            if self._closed:
+                slot.jobs.put(None)
+                return template
+            self._jobs.add(job)
+            with slot.lock:
+                slot.active = job
+        try:
+            if slot.thread is None:
+                slot.thread = threading.Thread(target=self._slot_loop, args=(slot,), daemon=True)
+                try:
+                    slot.thread.start()
+                except Exception:
+                    slot.thread = None
+                    raise
+            slot.jobs.put((job, template, context, sandbox_builder))
+        except Exception:
+            with self._lock:
+                self._jobs.discard(job)
+                if not self._closed:
+                    self._idle.put(slot)
+            logger.warning("isolated render supervisor could not start")
+            return template
+        try:
+            if not job.done.wait(remaining(deadline)):
+                raise _RenderTimeout()
+            remaining(deadline)
+        except _RenderTimeout:
+            job.cancel()
+            logger.warning("isolated render deadline exceeded (%ss)", self.timeout)
+            return template
+        except BaseException:
+            job.cancel()
+            raise
+        if job.cancelled.is_set() or self._closed:
+            return template
+        if job.error is not None:
+            logger.warning("isolated render failed: %s", type(job.error).__name__)
+            # Only a trusted parent-side compatibility decision may request fallback.
+            # A compromised/slow worker must never force rendering in the host.
+            if isinstance(job.error, UnsupportedContext):
+                return self._fallback(template, context, sandbox_builder)
+            return template
+        return job.result
 
 
 _BACKEND = None
+_BACKEND_LOCK = threading.Lock()
+_BACKEND_PID = os.getpid()
+
+
+def _backend_lock():
+    global _BACKEND_LOCK, _BACKEND_PID
+    if _BACKEND_PID != os.getpid():
+        _BACKEND_LOCK = threading.Lock()
+        _BACKEND_PID = os.getpid()
+    return _BACKEND_LOCK
 
 
 def _build_default_backend():
@@ -640,18 +822,21 @@ def _build_default_backend():
 def get_render_backend():
     """返回当前进程缓存的渲染后端单例（懒构造）。"""
     global _BACKEND
-    if _BACKEND is None:
-        _BACKEND = _build_default_backend()
-    return _BACKEND
+    with _backend_lock():
+        if _BACKEND is None:
+            _BACKEND = _build_default_backend()
+        return _BACKEND
 
 
 def set_render_backend(backend):
     """显式设置渲染后端（用于配置注入与测试）。"""
     global _BACKEND
-    _BACKEND = backend
+    with _backend_lock():
+        previous, _BACKEND = _BACKEND, backend
+    if previous is not backend and hasattr(previous, "close"):
+        previous.close()
 
 
 def reset_render_backend():
     """清空缓存，使下次 ``get_render_backend`` 重新按配置构造。"""
-    global _BACKEND
-    _BACKEND = None
+    set_render_backend(None)

--- a/bamboo_engine/template/render_backend.py
+++ b/bamboo_engine/template/render_backend.py
@@ -1,0 +1,657 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+# 可插拔的 Mako 渲染后端（render backend）。
+#
+# 背景：整条渲染链里真正“执行用户表达式”的只有一处——``MakoTemplate(template)`` 编译 +
+# ``harden_template_builtins`` + ``render_unicode(**data)``。这一小段是全部 RCE 注入面。
+# 本模块把这一段从「进程内直接调用」抽象成一个可替换的 backend，为后续「无网无凭证的
+# 隔离渲染器（子进程池 / WASM）」留出唯一切点，而**默认行为保持进程内渲染、语义零变化**。
+#
+# 设计要点：
+#   * ``render(template, context, sandbox_builder)``：backend 内部负责用 ``sandbox_builder()``
+#     构造沙箱命名空间并与 ``context`` 合并。之所以传入 ``sandbox_builder`` 而不是已合并好的
+#     ``data``，是为了让隔离 backend 能在**子进程本地重建沙箱**（``datetime/re/json`` 等模块
+#     不可跨进程序列化），只需序列化 ``context``。
+#   * 编译失败 / 渲染失败一律 inert：返回原始 ``template`` 字符串并留日志，与历史行为一致，
+#     绝不因渲染异常打断整条流程。
+
+import atexit
+import inspect
+import logging
+import multiprocessing
+import os
+import pickle
+import queue
+import sys
+import threading
+
+from mako.template import Template as MakoTemplate
+from mako.exceptions import MakoException
+
+from bamboo_engine.config import Settings
+from bamboo_engine.template.sandbox import harden_template_builtins
+
+logger = logging.getLogger("root")
+
+
+def _render_with_sandbox(template, context, sandbox_dict):
+    """唯一的“执行用户表达式”实现：沙箱 dict + context 合并 → 编译 → harden → render_unicode。
+
+    进程内后端与隔离 worker **共用同一实现**，保证两条路径语义严格一致：编译失败 / 渲染失败一律
+    inert（返回原始 ``template`` 字符串并留日志），绝不抛出、绝不打断流程。
+    """
+    data = {}
+    data.update(sandbox_dict)
+    data.update(context)
+    try:
+        tm = MakoTemplate(template)
+    except (MakoException, SyntaxError) as e:
+        logger.error("pipeline resolve template[{}] error[{}]".format(template, e))
+        return template
+    harden_template_builtins(tm)
+    try:
+        resolved = tm.render_unicode(**data)
+    except Exception as e:
+        logger.warning("constant content({}) is invalid, data({}), error: {}".format(template, data, e))
+        return template
+    else:
+        return resolved
+
+
+class RenderBackend(object):
+    """渲染后端接口。实现方需保证：编译/渲染失败时返回原始 template（inert），不得抛出。"""
+
+    def render(self, template, context, sandbox_builder):
+        raise NotImplementedError
+
+
+class InProcessRenderBackend(RenderBackend):
+    """默认后端：在当前进程内编译并渲染，行为与历史 ``_render_template`` 完全一致。"""
+
+    def render(self, template, context, sandbox_builder):
+        return _render_with_sandbox(template, context, sandbox_builder())
+
+
+class SandboxSpec(object):
+    """可序列化的渲染沙箱配置，供隔离 backend 在子进程本地重建沙箱。
+
+    只携带字符串型配置（flavor + shield_words + import_modules），因此可安全跨进程 pickle；真正
+    带副作用、不可序列化的模块对象由 :meth:`build` 在目标进程本地重建。
+
+    * ``engine`` flavor → ``bamboo_engine.template.sandbox.build_sandbox``（无 mock builtins）
+    * ``legacy`` flavor → ``pipeline.core.data.sandbox_builder.build_sandbox``（含 mock builtins，
+      且 Django-free，可在精简 worker 里 import）
+    """
+
+    __slots__ = ("flavor", "shield_words", "import_modules")
+
+    def __init__(self, flavor, shield_words, import_modules):
+        self.flavor = flavor
+        self.shield_words = list(shield_words or [])
+        self.import_modules = dict(import_modules or {})
+
+    def build(self):
+        if self.flavor == "engine":
+            from bamboo_engine.template.sandbox import build_sandbox
+
+            return build_sandbox(self.shield_words, self.import_modules)
+        if self.flavor == "legacy":
+            # 延迟 import：仅隔离 worker / legacy 渲染路径需要；且该模块 Django-free。
+            from pipeline.core.data.sandbox_builder import build_sandbox
+
+            return build_sandbox(self.shield_words, self.import_modules)
+        raise ValueError("unknown sandbox flavor: {}".format(self.flavor))
+
+    def __getstate__(self):
+        return {"flavor": self.flavor, "shield_words": self.shield_words, "import_modules": self.import_modules}
+
+    def __setstate__(self, state):
+        self.flavor = state["flavor"]
+        self.shield_words = state["shield_words"]
+        self.import_modules = state["import_modules"]
+
+
+class SandboxProvider(object):
+    """把「进程内构造沙箱」与「可序列化沙箱 spec」打包在一起交给 render backend。
+
+    * ``__call__`` / :meth:`build`：进程内构造命名空间（可读可变全局，保持历史语义）——供
+      ``InProcessRenderBackend`` 使用，且与「直接传一个 builder 可调用」向后兼容。
+    * :meth:`spec`：返回 :class:`SandboxSpec`——供隔离 backend 序列化后在 worker 本地重建。
+    """
+
+    __slots__ = ("_build_fn", "_spec")
+
+    def __init__(self, build_fn, spec):
+        self._build_fn = build_fn
+        self._spec = spec
+
+    def __call__(self):
+        return self._build_fn()
+
+    def build(self):
+        return self._build_fn()
+
+    def spec(self):
+        return self._spec
+
+
+# --------------------------------------------------------------------------------------------------
+# 隔离渲染后端：无网无凭证的 spawn worker 进程池
+#
+# 设计依据：docs/specs/2026-09-04-mako-render-isolation-design.md。核心不变量——
+#   * 渲染面（唯一执行用户表达式处）搬进独立子进程；子进程 **无凭证**（启动即清洗 env）、
+#     后续可叠加 **无网络**（OS 加固钩子，Linux 生效）。即便渲染被 RCE 打穿，也拿不到全局
+#     密钥、连不出网络，无法把标准运维当跳板打生态。
+#   * worker 用 ``spawn`` 全新解释器，不 import Django / 业务 app / 凭证；沙箱由父进程序列化过来的
+#     ``SandboxSpec`` 在 worker 本地重建（engine / legacy 两种 flavor 都已 Django-free）。
+#   * warm 池复用（避免每次渲染新开进程），``max_uses`` 用后回收，每次渲染都以全新沙箱重建
+#     （pristine），杜绝跨执行状态泄漏。
+#   * 失败兜底 fail-safe：不可序列化 context / worker 异常 → 回退进程内渲染；渲染超时 → inert
+#     回显原始模板（**不**回退进程内，避免把 DoS 带回主进程）。
+# --------------------------------------------------------------------------------------------------
+
+# --------------------------------------------------------------------------------------------------
+# 可移植 context 归一化
+#
+# 无 Django 的最小 worker 只能 unpickle「builtin/stdlib 类型 + 本模块自带的类」。而 bk-sops 的 rich 内置
+# 变量（DataTableValue / SetGroupInfo / SetInfo / SetModuleInfo / SetDetailData）返回的对象虽只含 plain
+# data、父进程可 pickle，但其**类定义模块 import 即依赖 Django**，worker 侧 unpickle 会失败。
+#
+# 这些 rich 对象都是「属性包」：__init__ 里 eager ``setattr`` 把数据落进 ``__dict__``，只实现 ``__repr__``，
+# 模板用法就是属性访问 + 列表下标 + bare ``${var}``（取字符串）。因此在 pickle 前把它们忠实搬运成
+# Django-free 的 :class:`PortableRenderObject`（属性 + str/repr），即可让含 rich 变量的模板也进隔离渲染，
+# 而不是被迫回退进程内。只在隔离 backend 的发送路径做，进程内渲染仍见原对象、行为零变化。
+# --------------------------------------------------------------------------------------------------
+
+_PORTABLE_SCALAR_TYPES = (str, bytes, bytearray, bool, int, float, complex, type(None))
+_PORTABLE_MAX_DEPTH = 8
+
+
+class PortableRenderObject(object):
+    """Django-free 的属性包载体：镜像原 rich 对象的实例属性与字符串形态，供无 Django worker 本地重建。
+
+    * 保留 ``obj.__dict__`` 的属性 → 模板 ``${var.attr}`` / ``${var.attr[i]}`` 照常可用；
+    * ``__str__`` / ``__repr__`` 返回归一化时捕获的 ``str(obj)`` / ``repr(obj)`` → bare ``${var}`` 一致。
+
+    ``_portable_*`` 放 slots、不进 ``__dict__``：既不污染模板可见属性，也避免与原对象同名属性冲突。
+    自身定义在 bamboo_engine（worker 必可 import），故跨进程 unpickle 稳定成功。
+    """
+
+    __slots__ = ("__dict__", "_portable_str", "_portable_repr")
+
+    def __init__(self, attrs, str_value, repr_value):
+        self.__dict__.update(attrs)
+        self._portable_str = str_value
+        self._portable_repr = repr_value
+
+    def __str__(self):
+        return self._portable_str
+
+    def __repr__(self):
+        return self._portable_repr
+
+
+def _safe_text(value, fn):
+    try:
+        return fn(value)
+    except Exception:  # pragma: no cover - repr/str 抛错兜底
+        return "<unrepresentable>"
+
+
+def _portable_value(value, depth, seen):
+    # 标量：原样保留。
+    if isinstance(value, _PORTABLE_SCALAR_TYPES):
+        return value
+    # 可调用 / 类型 / 模块：pickle 按引用处理（stdlib/可 import 者 worker 侧可重建）；不能归一化，
+    # 否则会把函数变成不可调用的载体，破坏 ``${f()}``。
+    if callable(value) or isinstance(value, type) or inspect.ismodule(value):
+        return value
+    if depth >= _PORTABLE_MAX_DEPTH:
+        return value
+    # 容器：递归归一化元素。
+    if isinstance(value, dict):
+        return {k: _portable_value(v, depth + 1, seen) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_portable_value(v, depth + 1, seen) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_portable_value(v, depth + 1, seen) for v in value)
+    if isinstance(value, (set, frozenset)):
+        return type(value)(_portable_value(v, depth + 1, seen) for v in value)
+    # 属性包对象（有 ``__dict__``）：转成 PortableRenderObject；防环。
+    obj_dict = getattr(value, "__dict__", None)
+    if isinstance(obj_dict, dict):
+        vid = id(value)
+        if vid in seen:  # 环：只保留字符串形态、断链。
+            return PortableRenderObject({}, _safe_text(value, str), _safe_text(value, repr))
+        seen = seen | {vid}
+        attrs = {k: _portable_value(v, depth + 1, seen) for k, v in obj_dict.items()}
+        return PortableRenderObject(attrs, _safe_text(value, str), _safe_text(value, repr))
+    # 其它（无 ``__dict__``、非标量/容器/可调用，如 datetime/Decimal/lock）：原样保留，交给
+    # pickle / worker 决定——stdlib 可移植者正常重建，真不可序列化者由发送路径统一兜底。
+    return value
+
+
+def _portable_context(context):
+    """把渲染 context 归一化为「仅含 builtin/stdlib 类型 + PortableRenderObject」的可移植结构。
+
+    仅供隔离 backend 在 pickle 前调用；进程内渲染不经过它、行为完全不变。
+    """
+    seen = frozenset()
+    return {k: _portable_value(v, 0, seen) for k, v in context.items()}
+
+
+_STATUS_OK = 0
+_STATUS_ERR = 1
+
+# worker 启动即从 ``os.environ`` 摘除的凭证类 env（大小写不敏感子串匹配）。渲染是纯计算，几乎不
+# 需要任何 env，over-scrub 是安全的；这里覆盖蓝鲸生态常见密钥/连接串命名。可经
+# ``Settings.MAKO_RENDER_ENV_SCRUB_EXTRA`` 追加。
+DEFAULT_ENV_SCRUB_PATTERNS = (
+    "SECRET",
+    "PASSWORD",
+    "PASSWD",
+    "TOKEN",
+    "CREDENTIAL",
+    "PRIVATE_KEY",
+    "APP_SECRET",
+    "APP_TOKEN",
+    "ACCESS_KEY",
+    "SECRET_KEY",
+    "DSN",
+    "DATABASE_URL",
+    "MYSQL",
+    "REDIS",
+    "MONGO",
+    "BROKER",
+    "RABBITMQ",
+    "AMQP",
+    "BKREPO",
+    "BK_APP_SECRET",
+)
+
+# OS 级加固的默认参数（可经 backend 构造参数 / Settings 覆盖）。
+DEFAULT_OS_HARDEN_RLIMIT_CPU = 30  # 秒；CPU 时间硬上限，作为 wall-clock timeout 的兜底，杀死 ${9**9**9} 这类狂算
+DEFAULT_OS_HARDEN_RLIMIT_AS_MB = 1024  # MB；地址空间上限，抑制渲染面内存炸弹
+
+# 测试注入用的 OS 加固覆盖钩子。默认 None；置为可调用对象时，:func:`_apply_os_hardening` 优先执行它。
+# 注意：``spawn`` worker 会以全新解释器重新 import 本模块，故该覆盖只在**同进程**内生效（单测用），
+# 真实 worker 的加固由 :func:`_apply_os_hardening` 依据传入的 ``opts`` 在子进程本地施加。
+_OS_HARDENING_HOOK = None
+
+
+def _try_unshare_network():
+    """尽力把 worker 放进独立的空网络 namespace（Linux）。
+
+    需要 CAP_SYS_ADMIN / user namespace，普通部署常无权限而失败（EPERM）——此时仅 debug 记录并继续：
+    **凭证已被 env-scrub 清除**，即便有网也无法冒充平台身份，这是纵深防御而非唯一屏障。
+    """
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        clone_newnet = 0x40000000  # CLONE_NEWNET
+        if libc.unshare(clone_newnet) != 0:
+            err = ctypes.get_errno()
+            logger.debug(
+                "mako render worker unshare(CLONE_NEWNET) failed errno=%s (need userns/root); env already scrubbed",
+                err,
+            )
+    except Exception as e:  # pragma: no cover - 平台/权限差异
+        logger.debug("mako render worker network unshare unavailable: %s", e)
+
+
+def _scrub_environ(patterns):
+    """从当前进程 ``os.environ`` 摘除命中 ``patterns`` 的键（子串、大小写不敏感）。"""
+    if not patterns:
+        return
+    lowered = [p.lower() for p in patterns]
+    for key in list(os.environ.keys()):
+        low = key.lower()
+        if any(p in low for p in lowered):
+            os.environ.pop(key, None)
+
+
+def _apply_os_hardening(opts):
+    """在 worker 本地施加 OS 级加固（rlimits + 尽力无网）。Linux 生效，其它平台 no-op。
+
+    ``opts`` 为可跨进程序列化的 dict：``{"enabled", "no_network", "rlimit_cpu", "rlimit_as_mb"}``。
+    任何异常都不得打断渲染——加固失败时以 fail-open 记录日志继续（env-scrub 仍已生效）。
+    单测可通过设置模块级 ``_OS_HARDENING_HOOK`` 覆盖真实逻辑。
+    """
+    # 测试覆盖优先（仅同进程生效）。
+    if _OS_HARDENING_HOOK is not None:
+        try:
+            _OS_HARDENING_HOOK()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("mako render worker os-hardening hook failed: %s", e)
+        return
+    if not opts or not opts.get("enabled"):
+        return
+    if not sys.platform.startswith("linux"):
+        return  # macOS / 其它平台：加固不可用，no-op（隔离仍靠 spawn + env-scrub）
+
+    try:
+        import resource
+
+        def _set_rlimit(res, soft):
+            try:
+                cur_soft, hard = resource.getrlimit(res)
+                new_soft = soft if hard == resource.RLIM_INFINITY else min(soft, hard)
+                resource.setrlimit(res, (new_soft, hard))
+            except Exception as e:  # pragma: no cover - 平台差异
+                logger.debug("mako render worker setrlimit(%s) failed: %s", res, e)
+
+        # 禁 core dump：避免带凭证/context 的内存随 core 落盘。
+        _set_rlimit(resource.RLIMIT_CORE, 0)
+        cpu = opts.get("rlimit_cpu")
+        if cpu:
+            _set_rlimit(resource.RLIMIT_CPU, int(cpu))
+        as_mb = opts.get("rlimit_as_mb")
+        if as_mb:
+            _set_rlimit(resource.RLIMIT_AS, int(as_mb) * 1024 * 1024)
+    except Exception as e:  # pragma: no cover - defensive, never break rendering
+        logger.warning("mako render worker rlimit hardening failed: %s", e)
+
+    if opts.get("no_network"):
+        _try_unshare_network()
+
+
+def _worker_main(conn, scrub_patterns, harden_opts):
+    """隔离 worker 主循环（``spawn`` 目标，模块级函数）。
+
+    启动即清洗凭证 env + 应用 OS 加固；随后循环处理请求：每条请求本地重建沙箱（pristine）后渲染，
+    回送 ``(status, result)``。收到 ``None`` 或管道 EOF 时退出。
+    """
+    _scrub_environ(scrub_patterns)
+    _apply_os_hardening(harden_opts)
+    while True:
+        try:
+            payload = conn.recv_bytes()
+        except EOFError:
+            break
+        try:
+            request = pickle.loads(payload)
+        except Exception as e:
+            # worker 侧反序列化失败：父进程 pickle 成功、但 worker 无法 loads——典型如 rich 内置变量
+            # （DataTableValue / SetGroupInfo 等）的类定义模块在无 Django worker 里 import 失败。
+            # 必须**立即回 STATUS_ERR** 让父进程走统一兜底（回退进程内 / strict），否则父进程只能等满
+            # timeout 再 inert，既慢又破坏正常渲染。回复不依赖请求内容，可无条件发送。
+            try:
+                conn.send_bytes(pickle.dumps((_STATUS_ERR, "unpickle request failed: {!r}".format(e))))
+            except Exception:  # pragma: no cover - 管道断裂
+                break
+            continue
+        if request is None:  # stop sentinel
+            break
+        template, context, spec = request
+        try:
+            sandbox_dict = spec.build()
+            result = _render_with_sandbox(template, context, sandbox_dict)
+            reply = pickle.dumps((_STATUS_OK, result))
+        except Exception as e:  # 沙箱重建 / 结果序列化异常 → 让父进程回退进程内
+            reply = pickle.dumps((_STATUS_ERR, repr(e)))
+        try:
+            conn.send_bytes(reply)
+        except Exception:  # pragma: no cover - 管道断裂
+            break
+    try:
+        conn.close()
+    except Exception:  # pragma: no cover
+        pass
+
+
+class _RenderTimeout(Exception):
+    """单次隔离渲染超时。"""
+
+
+class _RenderWorker(object):
+    """一个 warm 渲染子进程 + 父进程侧管道句柄 + 使用计数。"""
+
+    def __init__(self, ctx, scrub_patterns, harden_opts):
+        parent_conn, child_conn = ctx.Pipe(duplex=True)
+        self._conn = parent_conn
+        self._proc = ctx.Process(
+            target=_worker_main,
+            args=(child_conn, list(scrub_patterns), dict(harden_opts or {})),
+            daemon=True,
+        )
+        self._proc.start()
+        child_conn.close()  # 父进程侧关闭子端句柄，仅保留 parent_conn
+        self.uses = 0
+
+    @property
+    def pid(self):
+        return self._proc.pid
+
+    def request(self, payload, timeout):
+        """发送已序列化请求，最多等 ``timeout`` 秒。超时抛 :class:`_RenderTimeout`。"""
+        self._conn.send_bytes(payload)
+        if not self._conn.poll(timeout):
+            raise _RenderTimeout()
+        resp = self._conn.recv_bytes()
+        self.uses += 1
+        return pickle.loads(resp)
+
+    def is_alive(self):
+        return self._proc.is_alive()
+
+    def stop(self):
+        """优雅停止：发 sentinel + join；必要时 terminate。"""
+        try:
+            self._conn.send_bytes(pickle.dumps(None))
+        except Exception:
+            pass
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+        self._proc.join(timeout=1)
+        if self._proc.is_alive():  # pragma: no cover - 兜底
+            self._proc.terminate()
+            self._proc.join(timeout=1)
+
+    def kill(self):
+        """强制回收（用于超时 / broken worker）。"""
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+        if self._proc.is_alive():
+            self._proc.terminate()
+        self._proc.join(timeout=1)
+
+
+class SubprocessPoolRenderBackend(RenderBackend):
+    """无网无凭证的 spawn worker 进程池渲染后端。
+
+    池不变量：``_idle`` 队列中始终维持 ``pool_size`` 个可用 worker——每次渲染 ``acquire`` 恰好取出
+    一个、结束后 ``release``/``discard`` 恰好放回一个（健康则复用，超 ``max_uses`` 或损坏则替换为
+    新 worker）。懒启动：构造时不 spawn，首次 ``render`` 才拉起池，避免 import 期 fork。
+    """
+
+    def __init__(
+        self,
+        pool_size=None,
+        max_uses=None,
+        timeout=None,
+        env_scrub_patterns=None,
+        fallback_inprocess=None,
+        mp_context="spawn",
+        os_harden=None,
+        no_network=None,
+        rlimit_cpu=None,
+        rlimit_as_mb=None,
+    ):
+        self.pool_size = int(pool_size or getattr(Settings, "MAKO_RENDER_POOL_SIZE", 4) or 4)
+        self.max_uses = int(max_uses or getattr(Settings, "MAKO_RENDER_MAX_USES", 500) or 500)
+        self.timeout = float(timeout or getattr(Settings, "MAKO_RENDER_TIMEOUT", 30) or 30)
+        # 兜底策略：默认 **strict**（无法隔离渲染即 inert 回显，不静默回退特权进程）。归一化已让绝大多数
+        # 合法 context（含 rich 内置变量）可进隔离渲染，故残余「不可序列化」多为异常/攻击者构造——此时
+        # strict 更安全，避免「加个 rich 变量 / 塞个不可序列化对象」把注入拽回有网有凭证的主进程。
+        # 灰度需要保可用时，可显式置 ``fallback_inprocess=True`` 或 ``MAKO_RENDER_FALLBACK_INPROCESS=True``。
+        if fallback_inprocess is None:
+            fallback_inprocess = bool(getattr(Settings, "MAKO_RENDER_FALLBACK_INPROCESS", False))
+        self.fallback_inprocess = fallback_inprocess
+        if env_scrub_patterns is None:
+            env_scrub_patterns = list(DEFAULT_ENV_SCRUB_PATTERNS) + list(
+                getattr(Settings, "MAKO_RENDER_ENV_SCRUB_EXTRA", []) or []
+            )
+        self._scrub_patterns = list(env_scrub_patterns)
+        # OS 级加固参数（Linux 生效）。默认开启：core dump 关闭 + CPU/内存 rlimits + 尽力无网。
+        if os_harden is None:
+            os_harden = bool(getattr(Settings, "MAKO_RENDER_OS_HARDEN", True))
+        if no_network is None:
+            no_network = bool(getattr(Settings, "MAKO_RENDER_NO_NETWORK", True))
+        self._harden_opts = {
+            "enabled": bool(os_harden),
+            "no_network": bool(no_network),
+            "rlimit_cpu": rlimit_cpu
+            if rlimit_cpu is not None
+            else getattr(Settings, "MAKO_RENDER_RLIMIT_CPU", DEFAULT_OS_HARDEN_RLIMIT_CPU),
+            "rlimit_as_mb": rlimit_as_mb
+            if rlimit_as_mb is not None
+            else getattr(Settings, "MAKO_RENDER_RLIMIT_AS_MB", DEFAULT_OS_HARDEN_RLIMIT_AS_MB),
+        }
+        self._ctx = multiprocessing.get_context(mp_context)
+        self._idle = queue.Queue()
+        self._inprocess = InProcessRenderBackend()
+        self._lock = threading.Lock()
+        self._started = False
+        self._closed = False
+
+    # -- 池生命周期 --
+
+    def _spawn_worker(self):
+        return _RenderWorker(self._ctx, self._scrub_patterns, self._harden_opts)
+
+    def _ensure_started(self):
+        if self._started:
+            return
+        with self._lock:
+            if self._started:
+                return
+            for _ in range(self.pool_size):
+                self._idle.put(self._spawn_worker())
+            self._started = True
+            atexit.register(self.close)
+
+    def _acquire(self):
+        return self._idle.get()
+
+    def _release(self, worker):
+        """归还一个 worker：健康且未超 ``max_uses`` 则复用，否则停掉并补一个新 worker。"""
+        if self._closed:
+            worker.stop()
+            return
+        if worker.is_alive() and worker.uses < self.max_uses:
+            self._idle.put(worker)
+        else:
+            worker.stop()
+            self._idle.put(self._spawn_worker())
+
+    def _discard(self, worker):
+        """丢弃一个损坏 / 超时 worker，并补一个新 worker 维持池容量。"""
+        worker.kill()
+        if not self._closed:
+            self._idle.put(self._spawn_worker())
+
+    def close(self):
+        """停掉池内所有空闲 worker（幂等）。在飞的渲染完成后其 worker 也会被 stop。"""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        while True:
+            try:
+                worker = self._idle.get_nowait()
+            except queue.Empty:
+                break
+            worker.stop()
+
+    # -- 渲染 --
+
+    def _fallback(self, template, context, sandbox_builder):
+        if self.fallback_inprocess:
+            return self._inprocess.render(template, context, sandbox_builder)
+        return template
+
+    def render(self, template, context, sandbox_builder):
+        spec = sandbox_builder.spec() if hasattr(sandbox_builder, "spec") else None
+        if spec is None:
+            # 拿不到可序列化 spec（历史裸 builder）→ 无法隔离 → 进程内渲染，保持向后兼容。
+            return self._inprocess.render(template, context, sandbox_builder)
+        try:
+            # 归一化 rich context 对象为 Django-free 载体，让含 rich 变量的模板也能进隔离渲染；随后整体
+            # 预序列化，在**不污染管道**的前提下探测残余不可 pickle 的 context，命中即按策略兜底。
+            payload = pickle.dumps((template, _portable_context(context), spec))
+        except Exception as e:
+            logger.warning(
+                "render context not serializable, fallback(%s): %s",
+                "inprocess" if self.fallback_inprocess else "strict-inert",
+                e,
+            )
+            return self._fallback(template, context, sandbox_builder)
+
+        self._ensure_started()
+        worker = self._acquire()
+        try:
+            status, result = worker.request(payload, self.timeout)
+        except _RenderTimeout:
+            logger.warning("isolated render timeout(%ss), inert: %s", self.timeout, template)
+            self._discard(worker)
+            return template  # 超时 inert；绝不回退进程内，避免把 DoS 带回主进程
+        except Exception as e:
+            logger.warning("isolated render worker error, fallback in-process: %s", e)
+            self._discard(worker)
+            return self._fallback(template, context, sandbox_builder)
+        else:
+            self._release(worker)
+            if status == _STATUS_OK:
+                return result
+            logger.warning("isolated render sandbox error(%s), fallback in-process", result)
+            return self._fallback(template, context, sandbox_builder)
+
+
+_BACKEND = None
+
+
+def _build_default_backend():
+    """按 ``Settings.MAKO_RENDER_BACKEND`` 构造后端；未配置或未知值时回退进程内渲染。"""
+    name = getattr(Settings, "MAKO_RENDER_BACKEND", "inprocess") or "inprocess"
+    if name == "inprocess":
+        return InProcessRenderBackend()
+    if name == "subprocess":
+        return SubprocessPoolRenderBackend()
+    logger.warning("unknown MAKO_RENDER_BACKEND=%s, fallback to inprocess", name)
+    return InProcessRenderBackend()
+
+
+def get_render_backend():
+    """返回当前进程缓存的渲染后端单例（懒构造）。"""
+    global _BACKEND
+    if _BACKEND is None:
+        _BACKEND = _build_default_backend()
+    return _BACKEND
+
+
+def set_render_backend(backend):
+    """显式设置渲染后端（用于配置注入与测试）。"""
+    global _BACKEND
+    _BACKEND = backend
+
+
+def reset_render_backend():
+    """清空缓存，使下次 ``get_render_backend`` 重新按配置构造。"""
+    global _BACKEND
+    _BACKEND = None

--- a/bamboo_engine/template/render_transport.py
+++ b/bamboo_engine/template/render_transport.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""Bounded, non-executable worker replies and deadline-aware POSIX socket framing."""
+import json
+import socket
+import struct
+import time
+
+
+MAX_REQUEST_BYTES = 8 * 1024 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+
+
+class RenderTimeout(Exception):
+    pass
+
+
+class ProtocolError(ValueError):
+    pass
+
+
+def remaining(deadline):
+    left = deadline - time.monotonic()
+    if left <= 0:
+        raise RenderTimeout()
+    return left
+
+
+def encode_reply(status, result, request_id="0" * 32):
+    if type(status) is not int or status not in (0, 1) or type(result) is not str:
+        raise ProtocolError("invalid render reply")
+    if len(result) > MAX_RESPONSE_BYTES:
+        raise ProtocolError("render reply too large")
+    data = json.dumps([1, request_id, status, result], ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(data) > MAX_RESPONSE_BYTES:
+        raise ProtocolError("render reply too large")
+    return data
+
+
+def decode_reply(data, request_id="0" * 32):
+    if len(data) > MAX_RESPONSE_BYTES:
+        raise ProtocolError("render reply too large")
+    # Require the canonical, fixed header BEFORE invoking the JSON decoder. Only a
+    # string is then parsed: a hostile nested object or giant integer cannot allocate
+    # an arbitrarily large object graph or monopolize the host's integer conversion.
+    prefix = b'[1,"' + request_id.encode("ascii") + b'",'
+    if not data.startswith(prefix) or not data.endswith(b"]"):
+        raise ProtocolError("invalid render reply header")
+    body = data[len(prefix) :]
+    if body[:3] not in (b'0,"', b'1,"'):
+        raise ProtocolError("invalid render reply body")
+    try:
+        result = json.loads(body[2:-1].decode("utf-8"))
+    except (ValueError, UnicodeError, RecursionError) as exc:
+        raise ProtocolError("invalid render reply") from exc
+    if type(result) is not str:
+        raise ProtocolError("invalid render reply")
+    return [int(body[:1]), result]
+
+
+class SocketConnection:
+    """One uint32 length followed by bytes; check size before allocating a body."""
+
+    def __init__(self, sock):
+        self.sock = sock
+
+    def _timeout(self, deadline):
+        self.sock.settimeout(None if deadline is None else remaining(deadline))
+
+    def send_bytes(self, data, deadline=None, max_bytes=MAX_REQUEST_BYTES):
+        if len(data) > max_bytes:
+            raise ProtocolError("render request too large")
+        try:
+            # Keep the header and body separate: do not copy a large request again.
+            for part in (struct.pack("!I", len(data)), data):
+                view = memoryview(part)
+                while view:
+                    self._timeout(deadline)
+                    sent = self.sock.send(view)
+                    if not sent:
+                        raise EOFError()
+                    view = view[sent:]
+        except socket.timeout as exc:
+            raise RenderTimeout() from exc
+
+    def _read(self, size, deadline):
+        chunks = bytearray()
+        while len(chunks) < size:
+            self._timeout(deadline)
+            chunk = self.sock.recv(min(size - len(chunks), 65536))
+            if not chunk:
+                raise EOFError()
+            chunks.extend(chunk)
+        return bytes(chunks)
+
+    def recv_bytes(self, deadline=None, max_bytes=MAX_RESPONSE_BYTES):
+        try:
+            size = struct.unpack("!I", self._read(4, deadline))[0]
+            if size > max_bytes:
+                raise ProtocolError("render frame too large")
+            return self._read(size, deadline)
+        except socket.timeout as exc:
+            raise RenderTimeout() from exc
+
+    def close(self):
+        try:
+            self.sock.close()
+        except OSError:
+            pass

--- a/bamboo_engine/template/sandbox.py
+++ b/bamboo_engine/template/sandbox.py
@@ -17,9 +17,65 @@ specific language governing permissions and limitations under the License.
 
 from typing import List, Dict
 
+import logging
 import importlib
 
 from bamboo_engine.config import Settings
+
+logger = logging.getLogger("root")
+
+
+# 渲染期从模板模块 ``__builtins__`` 中摘除的危险内建。
+#
+# Mako 会把每段模板编译进一个独立 module，其 ``__builtins__`` 默认指向**真实** builtins。
+# 模板里通过 ``(g).gi_frame.f_builtins`` / ``frame.f_globals['__builtins__']`` 等反射链路
+# 拿到的正是这个 module 的 builtins。即便 AST deny-list 漏掉了某条通向 frame 的属性，
+# 只要这里事先把可直接"执行代码 / 读写文件"的原语摘掉，攻击者拿到的 builtins 视图里也
+# 不再有可用武器，是 deny-list 之外的纵深防御（capability allow-list by removal）。
+#
+# 仅摘除"非 ``__`` 前缀、可当作下标 key 直接取用"的执行 / IO 原语：
+# ``f_builtins['eval'](...)`` / ``['exec'](...)`` / ``['open'](...)`` 这类。
+# 刻意**保留** ``__import__``：它是 ``__`` 前缀（下标 / 属性 / 名称三条路径都已被
+# dunder 规则拦死，无法被直接取用），且 CPython 的 C 扩展在渲染期会惰性 import
+# （如 ``datetime.strftime`` 内部 ``import time``），摘掉会误伤正常渲染。
+# 同样保留 ``str/len/range`` 等 Mako codegen 与业务表达式需要的安全内建。
+DANGEROUS_RENDER_BUILTINS = frozenset(
+    {
+        "eval",
+        "exec",
+        "compile",
+        "open",
+        "input",
+        "breakpoint",
+    }
+)
+
+_RESTRICTED_BUILTINS = None
+
+
+def restricted_builtins() -> dict:
+    """返回去除 :data:`DANGEROUS_RENDER_BUILTINS` 后的 builtins 视图（只读、进程内缓存）。"""
+    global _RESTRICTED_BUILTINS
+    if _RESTRICTED_BUILTINS is None:
+        import builtins as _builtins
+
+        safe = {name: getattr(_builtins, name) for name in dir(_builtins)}
+        for name in DANGEROUS_RENDER_BUILTINS:
+            safe.pop(name, None)
+        _RESTRICTED_BUILTINS = safe
+    return _RESTRICTED_BUILTINS
+
+
+def harden_template_builtins(mako_template) -> None:
+    """把编译后模板模块的 ``__builtins__`` 换成去除危险原语的视图。
+
+    需在任何一次 render 创建 frame 之前调用。Mako 各版本内部结构略有差异，任何异常都不应
+    影响正常渲染，因此整体 try/except 兜底。
+    """
+    try:
+        mako_template.module.__builtins__ = restricted_builtins()
+    except Exception:  # pragma: no cover - defensive, never break rendering
+        logger.warning("failed to harden mako template builtins")
 
 
 def _shield_words(sandbox: dict, words: List[str]):

--- a/bamboo_engine/template/sandbox.py
+++ b/bamboo_engine/template/sandbox.py
@@ -83,6 +83,97 @@ def _shield_words(sandbox: dict, words: List[str]):
         sandbox[shield_word] = None
 
 
+# 绝不允许注入 ``MAKO_SANDBOX_IMPORT_MODULES`` 的模块根。
+#
+# 注入模块白名单是整个沙箱的信任根：一旦把下列任意模块注入渲染命名空间，攻击者无需触碰
+# dunder / frame，直接 ``${module.<primitive>(...)}`` 就能执行代码 / 导入 / 反序列化 /
+# 读写文件，AST deny-list 与根名白名单全部形同虚设（例如 ``operator.attrgetter('__globals__')``
+# 用字符串绕过 dunder 检查、``pickle.loads`` 反序列化、``os.system`` 直接命令执行）。
+# 这里在注入入口做一层 deny-list 兜底：即便接入方误配置，也拒绝把这些模块放进沙箱。
+DANGEROUS_IMPORT_MODULE_ROOTS = frozenset(
+    {
+        "os",
+        "sys",
+        "subprocess",
+        "importlib",
+        "imp",
+        "runpy",
+        "operator",
+        "inspect",
+        "pickle",
+        "_pickle",
+        "cpickle",
+        "marshal",
+        "shelve",
+        "dill",
+        "ctypes",
+        "cffi",
+        "pty",
+        "platform",
+        "pydoc",
+        "code",
+        "codeop",
+        "builtins",
+        "__builtin__",
+        "gc",
+        "socket",
+        "shutil",
+        "signal",
+        "multiprocessing",
+        "threading",
+        "_thread",
+        "mmap",
+        "fcntl",
+        "resource",
+        "tempfile",
+        "pdb",
+        "bdb",
+        "trace",
+        "timeit",
+        "ast",
+        "compileall",
+        "py_compile",
+    }
+)
+
+# deny-list 的例外：这些子模块本身不暴露执行原语，历史上被业务合法注入（如 ``os.path`` 的
+# ``join / exists``）。``os.path.os`` / ``os.path.sys`` 这类反向 pivot 已由 always-on 的属性
+# deny-list（``DANGEROUS_ATTR_NAMES``）拦截，因此保留 ``os.path`` 是安全的。
+SAFE_IMPORT_SUBMODULES = frozenset({"os.path"})
+
+_WARNED_DANGEROUS_IMPORTS = set()
+
+
+def _is_dangerous_import(mod_path: str) -> bool:
+    if not mod_path:
+        return False
+    if mod_path in SAFE_IMPORT_SUBMODULES:
+        return False
+    root = mod_path.split(".", 1)[0]
+    return root in DANGEROUS_IMPORT_MODULE_ROOTS
+
+
+def filter_import_modules(modules: Dict[str, str]) -> Dict[str, str]:
+    """剔除 deny-list 中的危险模块，返回可安全注入沙箱的子集。
+
+    命中危险模块时不抛异常（避免误配置直接打挂全部渲染），改为跳过 + 记录一次 error 日志，
+    保证系统 fail-safe：危险模块不会进入渲染命名空间，依赖它的模板会以 inert 形式失败并留痕。
+    """
+    safe = {}
+    for mod_path, alias in modules.items():
+        if _is_dangerous_import(mod_path):
+            if mod_path not in _WARNED_DANGEROUS_IMPORTS:
+                _WARNED_DANGEROUS_IMPORTS.add(mod_path)
+                logger.error(
+                    "refuse to inject dangerous module into mako sandbox: %s (alias=%s)",
+                    mod_path,
+                    alias,
+                )
+            continue
+        safe[mod_path] = alias
+    return safe
+
+
 class ModuleObject:
     def __init__(self, sub_paths, module):
         if len(sub_paths) == 1:
@@ -103,6 +194,7 @@ def resolve_import_object(mod_path):
 
 
 def _import_modules(sandbox: dict, modules: Dict[str, str]):
+    modules = filter_import_modules(modules)
     items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
     for mod_path, alias in items:
         obj = resolve_import_object(mod_path)

--- a/bamboo_engine/template/sandbox.py
+++ b/bamboo_engine/template/sandbox.py
@@ -35,14 +35,30 @@ class ModuleObject:
         setattr(self, sub_paths[0], ModuleObject(sub_paths[1:], module))
 
 
+def resolve_import_object(mod_path):
+    try:
+        return importlib.import_module(mod_path)
+    except ImportError:
+        parts = mod_path.split(".")
+        obj = importlib.import_module(parts[0])
+        for part in parts[1:]:
+            obj = getattr(obj, part)
+        return obj
+
+
 def _import_modules(sandbox: dict, modules: Dict[str, str]):
-    for mod_path, alias in modules.items():
-        mod = importlib.import_module(mod_path)
+    items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
+    for mod_path, alias in items:
+        obj = resolve_import_object(mod_path)
         sub_paths = alias.split(".")
         if len(sub_paths) == 1:
-            sandbox[alias] = mod
-        else:
-            sandbox[sub_paths[0]] = ModuleObject(sub_paths[1:], mod)
+            sandbox[alias] = obj
+            continue
+        root = sub_paths[0]
+        existing = sandbox.get(root)
+        if existing is not None and not isinstance(existing, ModuleObject):
+            continue
+        sandbox[root] = ModuleObject(sub_paths[1:], obj)
 
 
 def get() -> dict:

--- a/bamboo_engine/template/sandbox.py
+++ b/bamboo_engine/template/sandbox.py
@@ -209,10 +209,18 @@ def _import_modules(sandbox: dict, modules: Dict[str, str]):
         sandbox[root] = ModuleObject(sub_paths[1:], obj)
 
 
-def get() -> dict:
+def build_sandbox(shield_words, import_modules) -> dict:
+    """从（shield_words, import_modules）配置构造一个全新的渲染沙箱命名空间（不读 Settings）。
+
+    与 :func:`get` 同源，但配置由参数传入，因此可在**无网无凭证的隔离渲染子进程**里用（从父进程
+    序列化过来的）配置本地重建沙箱，而不必依赖子进程侧的 Settings。engine flavor 不含 legacy 的
+    mock builtins。
+    """
     sandbox = {}
-
-    _shield_words(sandbox, Settings.MAKO_SANDBOX_SHIELD_WORDS)
-    _import_modules(sandbox, Settings.MAKO_SANDBOX_IMPORT_MODULES)
-
+    _shield_words(sandbox, shield_words or [])
+    _import_modules(sandbox, import_modules or {})
     return sandbox
+
+
+def get() -> dict:
+    return build_sandbox(Settings.MAKO_SANDBOX_SHIELD_WORDS, Settings.MAKO_SANDBOX_IMPORT_MODULES)

--- a/bamboo_engine/template/template.py
+++ b/bamboo_engine/template/template.py
@@ -23,6 +23,7 @@ from mako.template import Template as MakoTemplate
 from mako import lexer, codegen
 from mako.exceptions import MakoException
 
+from bamboo_engine.config import Settings
 from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
 from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 from bamboo_engine.utils import mako_safety
@@ -159,6 +160,24 @@ class Template:
             except Exception:
                 logger.exception("{} safety check error.".format(tpl))
                 continue
+            # 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``）。off 模式下保持
+            # 历史行为；warn 模式只打日志；enforce 模式命中即按 SingleLineNodeVisitor
+            # 风格 inert 掉这一段模板（``logger.warning + continue``）。
+            whitelist_mode = getattr(Settings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", "off")
+            if whitelist_mode in ("warn", "enforce"):
+                allowed_names = mako_safety.build_allowed_names(context)
+                try:
+                    check_mako_template_safety(
+                        tpl,
+                        mako_safety.WhitelistNameVisitor(allowed_names, mode=whitelist_mode),
+                        mako_safety.SingleLinCodeExtractor(),
+                    )
+                except ForbiddenMakoTemplateException as e:
+                    logger.warning("forbidden by whitelist: {}, exception: {}".format(tpl, e))
+                    continue
+                except Exception:
+                    logger.exception("{} whitelist check error.".format(tpl))
+                    continue
             resolved = Template._render_template(tpl, context)
             string = string.replace(tpl, resolved)
         return string

--- a/bamboo_engine/template/template.py
+++ b/bamboo_engine/template/template.py
@@ -205,6 +205,7 @@ class Template:
         except (MakoException, SyntaxError) as e:
             logger.error("pipeline resolve template[{}] error[{}]".format(template, e))
             return template
+        sandbox.harden_template_builtins(tm)
         try:
             resolved = tm.render_unicode(**data)
         except Exception as e:

--- a/bamboo_engine/template/template.py
+++ b/bamboo_engine/template/template.py
@@ -19,7 +19,6 @@ import logging
 
 from typing import Any, List, Set
 
-from mako.template import Template as MakoTemplate
 from mako import lexer, codegen
 from mako.exceptions import MakoException
 
@@ -30,6 +29,7 @@ from bamboo_engine.utils import mako_safety
 from bamboo_engine.utils.string import deformat_var_key
 
 from . import sandbox
+from .render_backend import get_render_backend, SandboxProvider, SandboxSpec
 
 
 logger = logging.getLogger("root")
@@ -195,21 +195,14 @@ class Template:
         :return: [description]
         :rtype: str
         """
-        data = {}
-        data.update(sandbox.get())
-        data.update(context)
         if not isinstance(template, str):
             raise TypeError("constant resolve error, template[%s] is not a string" % template)
-        try:
-            tm = MakoTemplate(template)
-        except (MakoException, SyntaxError) as e:
-            logger.error("pipeline resolve template[{}] error[{}]".format(template, e))
-            return template
-        sandbox.harden_template_builtins(tm)
-        try:
-            resolved = tm.render_unicode(**data)
-        except Exception as e:
-            logger.warning("constant content({}) is invalid, data({}), error: {}".format(template, data, e))
-            return template
-        else:
-            return resolved
+        # 唯一的“执行用户表达式”入口下沉到可插拔的 render backend：默认 ``InProcessRenderBackend``
+        # 行为与历史完全一致（沙箱 dict + context 合并、harden、render_unicode、编译/渲染失败 inert）。
+        # provider 同时提供：进程内 ``sandbox.get`` 现场构造，与可序列化的 ``SandboxSpec``（供隔离
+        # backend 在子进程本地重建沙箱、只序列化 context）。见 bamboo_engine/template/render_backend.py。
+        provider = SandboxProvider(
+            sandbox.get,
+            SandboxSpec("engine", Settings.MAKO_SANDBOX_SHIELD_WORDS, Settings.MAKO_SANDBOX_IMPORT_MODULES),
+        )
+        return get_render_backend().render(template, context, provider)

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -14,7 +14,9 @@ specific language governing permissions and limitations under the License.
 # Mako 安全工具
 
 
-from ast import NodeVisitor
+import ast
+import logging
+import re
 
 from mako import parsetree
 
@@ -22,7 +24,127 @@ from .mako_utils.code_extract import MakoNodeCodeExtractor
 from .mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
-class SingleLineNodeVisitor(NodeVisitor):
+logger = logging.getLogger("root")
+
+# 与 ``MAKO_SANDBOX_SHIELD_WORDS`` 不重叠的"安全内建函数"集合。
+# 用于白名单模式下默认放行的根标识符。
+# 不包含 ``bytes/bytearray/frozenset/memoryview/object/type/vars/getattr/...``
+# 等常出现在 shield 列表中的内建——它们即便能通过 AST 也会在渲染期被屏蔽成 ``None``，
+# 留在白名单里只会带来认知噪音。
+SAFE_BUILTIN_NAMES = frozenset(
+    {
+        "True",
+        "False",
+        "None",
+        # 类型构造（不会构造危险对象）
+        "bool",
+        "int",
+        "float",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        # 数学 / 长度
+        "abs",
+        "round",
+        "pow",
+        "sum",
+        "min",
+        "max",
+        "len",
+        # 序列
+        "range",
+        "slice",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        # 逻辑
+        "all",
+        "any",
+    }
+)
+
+# Mako 在渲染期会向模板命名空间注入的保留对象名，用户模板里出现这些名字时
+# 极大概率是在尝试触达模板内部对象（``self.module.cache.util.os...`` SSTI 链路）。
+# 对它们直接拒绝，可以堵住绝大多数 namespace 链式 RCE 路径。
+MAKO_RESERVED_NAMESPACES = frozenset(
+    {
+        "self",
+        "context",
+        "local",
+        "parent",
+        "next",
+        "caller",
+        "pageargs",
+        "UNDEFINED",
+        "STOP_RENDERING",
+    }
+)
+
+# attr 链路上一旦出现下列名字就立刻拒绝。
+#
+# 根 ``Name`` 白名单只能防"未授权根标识符"，挡不住通过白名单根名（如 ``os``、``datetime``、
+# ``re``）反向触达危险模块的链路：
+#
+# * ``${os.path.os.popen(...)}``        — ``os.path`` 内部 ``import os``
+# * ``${datetime.sys.modules['os']...}`` — ``datetime`` 内部 ``import sys``
+# * ``${re.enum.sys.modules['os']...}``  — ``re`` 重新 export ``enum``，``enum`` 内 ``import sys``
+#
+# 所有这些链路都需要 attr 链上出现 ``os / sys / subprocess / shutil / ctypes / socket /
+# builtins / modules`` 之一，或调用 ``popen / system / exec* / spawn* / fork*`` 之一。
+# 直接把 attr 名拉黑，就能切掉公共必经路径。这是纵深防御里的"任何路径都不该带这些字"，
+# 不是替代根名白名单。
+DANGEROUS_ATTR_NAMES = frozenset(
+    {
+        # 直接拿到危险模块对象
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "ctypes",
+        "socket",
+        "_thread",
+        "threading",
+        "builtins",
+        "__builtins__",
+        # 通过模块字典反向触达任意已导入模块
+        "modules",
+        # 进程 / 文件描述符相关原语（即便有人未来误把 ``os`` 加进白名单，也再加一层）
+        "popen",
+        "popen2",
+        "popen3",
+        "popen4",
+        "system",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "kill",
+    }
+)
+
+FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
+SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class SingleLineNodeVisitor(ast.NodeVisitor):
     """
     遍历语法树节点，遇到魔术方法使用或 import 时，抛出异常
     """
@@ -30,19 +152,63 @@ class SingleLineNodeVisitor(NodeVisitor):
     def __init__(self, *args, **kwargs):
         super(SingleLineNodeVisitor, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def _get_subscript_key(node):
+        slice_node = node.slice
+        constant_node = getattr(ast, "Constant", None)
+        if (
+            constant_node is not None
+            and isinstance(slice_node, constant_node)
+            and isinstance(slice_node.value, str)
+        ):
+            return slice_node.value
+        if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):
+            return slice_node.s
+        return None
+
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Name(self, node):
         if node.id.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private method")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        subscript_key = self._get_subscript_key(node)
+        if isinstance(subscript_key, str) and subscript_key.startswith("__"):
+            raise ForbiddenMakoTemplateException("can not access private key")
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         raise ForbiddenMakoTemplateException("can not use import statement")
 
     def visit_ImportFrom(self, node):
         self.visit_Import(node)
+
+
+def validate_filter_args(filter_args):
+    for filter_arg in filter_args:
+        normalized_filter = filter_arg.strip()
+        if normalized_filter in SAFE_FILTERS:
+            continue
+        decode_filter_parts = normalized_filter.split(".")
+        if (
+            SAFE_DECODE_FILTER_PATTERN.match(normalized_filter)
+            and "__" not in normalized_filter
+            and not any(part.startswith("_") for part in decode_filter_parts[1:])
+        ):
+            continue
+        raise ForbiddenMakoTemplateException("unsupported filter expression: [{}]".format(normalized_filter))
 
 
 class SingleLinCodeExtractor(MakoNodeCodeExtractor):
@@ -53,3 +219,161 @@ class SingleLinCodeExtractor(MakoNodeCodeExtractor):
             return None
         else:
             raise ForbiddenMakoTemplateException("Unsupported node: [{}]".format(node.__class__.__name__))
+
+
+def _deformat_var_key(key):
+    """``${name}`` -> ``name``；其它 key 原样返回。"""
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def build_allowed_names(context, *, extra=()):
+    """根据当前渲染 context 与全局 ``Settings`` 计算白名单的根标识符集合。
+
+    包含：
+      * ``context`` 中的键（``${name}`` 形式自动 deformat）
+      * ``Settings.MAKO_SANDBOX_IMPORT_MODULES`` 中每个 alias 的首段
+        （例：``os.path`` → ``os``）
+      * :data:`SAFE_BUILTIN_NAMES`
+      * ``Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST``
+      * 调用方传入的 ``extra``
+    """
+    # 局部 import 避免循环依赖（``Settings`` 在 ``bamboo_engine.config``）。
+    from bamboo_engine.config import Settings
+
+    allowed = set(SAFE_BUILTIN_NAMES)
+
+    for key in context.keys() if context else ():
+        allowed.add(_deformat_var_key(key))
+
+    import_modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    for alias in import_modules.values():
+        if alias:
+            allowed.add(alias.split(".", 1)[0])
+
+    extra_whitelist = getattr(Settings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", None) or ()
+    allowed.update(extra_whitelist)
+    allowed.update(extra)
+
+    return allowed
+
+
+class WhitelistNameVisitor(ast.NodeVisitor):
+    """根标识符白名单 visitor。
+
+    只允许 Load 语义的 ``Name`` 节点引用 ``allowed_names`` 中的标识符；其余一律按
+    ``mode`` 处理：
+
+      * ``warn``：调用 ``on_violation`` / 打 warning 日志，**不抛异常**（灰度模式）。
+      * ``enforce``：抛 :exc:`ForbiddenMakoTemplateException`，由
+        :func:`bamboo_engine.utils.mako_utils.checker.check_mako_template_safety` 捕获。
+
+    本 visitor 还显式拦截 :data:`MAKO_RESERVED_NAMESPACES` 中的标识符，
+    无论是否被传入 ``allowed_names`` 都会被拒，避免误把 ``self/context/...`` 加进
+    上下文导致 SSTI 链路被放行。
+
+    支持 ``ListComp / SetComp / DictComp / GeneratorExp / Lambda`` 引入的局部
+    绑定——这些临时变量会被压入作用域栈，在子树访问完后自动弹出。
+    """
+
+    def __init__(self, allowed_names, mode="enforce", on_violation=None):
+        if mode not in {"warn", "enforce"}:
+            raise ValueError("invalid whitelist mode: {}".format(mode))
+        self.allowed_names = set(allowed_names)
+        self.mode = mode
+        self.on_violation = on_violation
+        self.scope_stack = []
+
+    def _name_allowed(self, name):
+        if name in MAKO_RESERVED_NAMESPACES:
+            return False
+        if name in self.allowed_names:
+            return True
+        for scope in self.scope_stack:
+            if name in scope:
+                return True
+        return False
+
+    def _violate(self, name, reason):
+        msg = "name not in whitelist: {} ({})".format(name, reason)
+        if self.on_violation is not None:
+            try:
+                self.on_violation(name, reason)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("on_violation callback raised")
+        if self.mode == "enforce":
+            raise ForbiddenMakoTemplateException(msg)
+        logger.warning("[mako_whitelist] %s", msg)
+
+    @staticmethod
+    def _collect_targets(target, into):
+        if isinstance(target, ast.Name):
+            into.add(target.id)
+        elif isinstance(target, ast.Starred):
+            WhitelistNameVisitor._collect_targets(target.value, into)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                WhitelistNameVisitor._collect_targets(elt, into)
+
+    def visit_Name(self, node):
+        # Store / Del 上下文是赋值/删除目标，由 _enter_* 显式处理，跳过命名检查
+        if not isinstance(node.ctx, ast.Load):
+            return
+        if node.id in MAKO_RESERVED_NAMESPACES:
+            self._violate(node.id, "mako reserved namespace")
+            return
+        if not self._name_allowed(node.id):
+            self._violate(node.id, "not in whitelist")
+
+    def visit_Attribute(self, node):
+        # 单下划线 attr 拒绝：堵 ``context._with_template / context._kwargs`` 这类
+        # Python "半私有" 通道（双下划线已经在 ``SingleLineNodeVisitor`` 拦过，这里
+        # 顺手收紧成单下划线，覆盖更广）。
+        if node.attr.startswith("_"):
+            self._violate(node.attr, "private attribute")
+            return
+        # 危险 attr 名拒绝：堵 ``${os.path.os.popen(...)}`` /
+        # ``${datetime.sys.modules['os'].popen(...)}`` 类反向引用链路。
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            self._violate(node.attr, "dangerous attribute")
+            return
+        self.generic_visit(node)
+
+    def _enter_comprehension(self, node):
+        local = set()
+        for gen in node.generators:
+            self._collect_targets(gen.target, local)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()
+
+    def visit_ListComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_SetComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_DictComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_GeneratorExp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_Lambda(self, node):
+        local = set()
+        args = node.args
+        local.update(arg.arg for arg in args.args)
+        local.update(arg.arg for arg in args.kwonlyargs)
+        local.update(arg.arg for arg in getattr(args, "posonlyargs", ()) or ())
+        if args.vararg:
+            local.add(args.vararg.arg)
+        if args.kwarg:
+            local.add(args.kwarg.arg)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -139,6 +139,50 @@ DANGEROUS_ATTR_NAMES = frozenset(
     }
 )
 
+# 生成器 / 协程 / 异步生成器 / traceback / frame 对象的反射属性。
+#
+# 这些名字都不是 ``__`` 前缀，因此逃过私有属性检查，也不在 :data:`DANGEROUS_ATTR_NAMES`
+# 里；但任意一个都能拿到一个 ``frame`` 对象，再顺着 ``frame.f_builtins`` /
+# ``frame.f_globals`` 直接取回**真实** builtins（``eval`` / ``exec`` / ``open`` /
+# ``__import__`` ...），是 deny-list 之外与配置无关的通用 RCE 入口：
+#
+#     ``${(i for i in [1]).gi_frame.f_builtins['eval']("__import__('os').system('id')")}``
+#
+# ``eval`` / ``exec`` 的实参是字符串常量，AST 不会解析其内容，所以一旦摸到 builtins
+# 字典，白名单 / 黑名单全部失效。这里把"通向 frame 的属性名"整体拒绝，从入口切断。
+FRAME_INTROSPECTION_ATTRS = frozenset(
+    {
+        # generator
+        "gi_frame",
+        "gi_code",
+        "gi_yieldfrom",
+        # coroutine
+        "cr_frame",
+        "cr_code",
+        "cr_await",
+        "cr_origin",
+        # async generator
+        "ag_frame",
+        "ag_code",
+        "ag_await",
+        # frame 对象
+        "f_back",
+        "f_builtins",
+        "f_globals",
+        "f_locals",
+        "f_code",
+        "f_trace",
+        # traceback 对象
+        "tb_frame",
+        "tb_next",
+        # 兼容老式函数内部属性别名（py2 时代，拦住无副作用）
+        "func_globals",
+        "func_code",
+        "func_closure",
+        "func_builtins",
+    }
+)
+
 FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
 SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
 SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
@@ -169,6 +213,8 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FRAME_INTROSPECTION_ATTRS:
+            raise ForbiddenMakoTemplateException("can not access frame or generator internals")
         if node.attr in FORBIDDEN_TEMPLATE_METHODS:
             raise ForbiddenMakoTemplateException("can not call forbidden method")
         self.generic_visit(node)
@@ -370,6 +416,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
             return
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
+            return
+        if node.attr in FRAME_INTROSPECTION_ATTRS:
+            self._violate(node.attr, "frame or generator internals")
             return
         kind, root, attrs = resolve_attr_chain(node)
         if kind == "name" and root in MAKO_RESERVED_NAMESPACES:

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -215,8 +215,19 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
             raise ForbiddenMakoTemplateException("can not access private attribute")
         if node.attr in FRAME_INTROSPECTION_ATTRS:
             raise ForbiddenMakoTemplateException("can not access frame or generator internals")
+        # 危险属性名（``os / sys / builtins / modules / system / popen ...``）与保留命名空间
+        # 属性链（``self.module... / context....``）改为 always-on 无条件拦截：它们原本只在
+        # ``WhitelistNameVisitor``（warn/enforce）里挡，导致 ``off`` 模式下仍可用
+        # ``${self.module.cache.util.os.system(...)}`` / ``${os.path.os.system(...)}`` /
+        # ``${json.codecs.builtins.exec(...)}`` 反向 pivot 到真实模块拿 RCE。这里下沉到
+        # ``SingleLineNodeVisitor``，任何模式（含 off）都切断这两条公共必经路径。
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            raise ForbiddenMakoTemplateException("can not access dangerous attribute")
         if node.attr in FORBIDDEN_TEMPLATE_METHODS:
             raise ForbiddenMakoTemplateException("can not call forbidden method")
+        root_kind, root_name, _attrs = resolve_attr_chain(node)
+        if root_kind == "name" and root_name in MAKO_RESERVED_NAMESPACES:
+            raise ForbiddenMakoTemplateException("can not access mako reserved namespace attribute")
         self.generic_visit(node)
 
     def visit_Name(self, node):

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -228,6 +228,45 @@ def _deformat_var_key(key):
     return key
 
 
+def resolve_attr_chain(node):
+    attrs = [node.attr]
+    cur = node.value
+    while isinstance(cur, ast.Attribute):
+        attrs.append(cur.attr)
+        cur = cur.value
+    attrs.reverse()
+    if isinstance(cur, ast.Name):
+        return "name", cur.id, attrs
+    if isinstance(cur, ast.Call):
+        return "call_result", None, attrs
+    return "other", None, attrs
+
+
+def import_chain_violation(root, attrs, aliases):
+    if not root:
+        return None
+    roots = set(alias.split(".", 1)[0] for alias in aliases)
+    if root not in roots:
+        return None
+    best_len = -1
+    for index in range(len(attrs) + 1):
+        candidate = root if index == 0 else "{}.{}".format(root, ".".join(attrs[:index]))
+        if candidate in aliases:
+            best_len = index
+    if best_len < 0:
+        return "import path not configured"
+    if len(attrs[best_len:]) > 1:
+        return "import attr deeper than one level"
+    return None
+
+
+def configured_import_aliases():
+    from bamboo_engine.config import Settings
+
+    modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    return frozenset(alias for alias in modules.values() if alias)
+
+
 def build_allowed_names(context, *, extra=()):
     """根据当前渲染 context 与全局 ``Settings`` 计算白名单的根标识符集合。
 
@@ -269,9 +308,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
       * ``enforce``：抛 :exc:`ForbiddenMakoTemplateException`，由
         :func:`bamboo_engine.utils.mako_utils.checker.check_mako_template_safety` 捕获。
 
-    本 visitor 还显式拦截 :data:`MAKO_RESERVED_NAMESPACES` 中的标识符，
-    无论是否被传入 ``allowed_names`` 都会被拒，避免误把 ``self/context/...`` 加进
-    上下文导致 SSTI 链路被放行。
+    光杆保留名（:data:`MAKO_RESERVED_NAMESPACES`）放行；保留名上的属性链仍拒，
+    避免 ``self.module...`` 一类 SSTI 链路被放行。单下划线 attr 不再一刀切，
+    仅双下划线与 :data:`DANGEROUS_ATTR_NAMES` 在属性节点上拦截。
 
     支持 ``ListComp / SetComp / DictComp / GeneratorExp / Lambda`` 引入的局部
     绑定——这些临时变量会被压入作用域栈，在子树访问完后自动弹出。
@@ -321,23 +360,26 @@ class WhitelistNameVisitor(ast.NodeVisitor):
         if not isinstance(node.ctx, ast.Load):
             return
         if node.id in MAKO_RESERVED_NAMESPACES:
-            self._violate(node.id, "mako reserved namespace")
             return
         if not self._name_allowed(node.id):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
-        # 单下划线 attr 拒绝：堵 ``context._with_template / context._kwargs`` 这类
-        # Python "半私有" 通道（双下划线已经在 ``SingleLineNodeVisitor`` 拦过，这里
-        # 顺手收紧成单下划线，覆盖更广）。
-        if node.attr.startswith("_"):
+        if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return
-        # 危险 attr 名拒绝：堵 ``${os.path.os.popen(...)}`` /
-        # ``${datetime.sys.modules['os'].popen(...)}`` 类反向引用链路。
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
             return
+        kind, root, attrs = resolve_attr_chain(node)
+        if kind == "name" and root in MAKO_RESERVED_NAMESPACES:
+            self._violate(root, "mako reserved namespace attribute")
+            return
+        if kind == "name":
+            reason = import_chain_violation(root, attrs, configured_import_aliases())
+            if reason:
+                self._violate(root, reason)
+                return
         self.generic_visit(node)
 
     def _enter_comprehension(self, node):

--- a/bamboo_engine/utils/mako_safety.py
+++ b/bamboo_engine/utils/mako_safety.py
@@ -183,7 +183,8 @@ FRAME_INTROSPECTION_ATTRS = frozenset(
     }
 )
 
-FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+# .format 保留 off/warn 下的存量兼容，仅 enforce 检查；format_map 仍始终拒绝。
+FORBIDDEN_TEMPLATE_METHODS = {"format_map"}
 SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
 SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
@@ -422,6 +423,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
+        if self.mode == "enforce" and node.attr == "format":
+            self._violate(node.attr, "forbidden method")
+            return
         if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return

--- a/bamboo_engine/utils/mako_utils/checker.py
+++ b/bamboo_engine/utils/mako_utils/checker.py
@@ -19,8 +19,19 @@ from mako import parsetree
 from mako.exceptions import MakoException
 from mako.lexer import Lexer
 
+from bamboo_engine.utils import mako_safety
+
 from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
+
+
+def validate_node_filter_callables(node: parsetree.Node):
+    # Mako stores inline `${expr | ...}` filter callables in `escapes_code`;
+    # tag-level filters use `filter_args`. Both are executed by create_filter_callable().
+    if hasattr(node, "escapes_code"):
+        mako_safety.validate_filter_args(node.escapes_code.args)
+    if hasattr(node, "filter_args"):
+        mako_safety.validate_filter_args(node.filter_args.args)
 
 
 def parse_template_nodes(
@@ -35,14 +46,15 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        code = code_extractor.extract(node)
-        if code is None:
-            continue
+        validate_node_filter_callables(node)
 
-        ast_node = ast.parse(code, "<unknown>", "exec")
-        node_visitor.visit(ast_node)
+        code = code_extractor.extract(node)
+        if code is not None:
+            ast_node = ast.parse(code, "<unknown>", "exec")
+            node_visitor.visit(ast_node)
+
         if hasattr(node, "nodes"):
-            parse_template_nodes(node.nodes, node_visitor)
+            parse_template_nodes(node.nodes, node_visitor, code_extractor)
 
 
 def check_mako_template_safety(text: str, node_visitor: ast.NodeVisitor, code_extractor: MakoNodeCodeExtractor) -> bool:

--- a/docs/mako-render-backend.md
+++ b/docs/mako-render-backend.md
@@ -1,0 +1,52 @@
+# Mako subprocess 渲染后端
+
+默认仍为 `inprocess`。宿主需在首次获取后端前配置 `bamboo_engine.config.Settings`，或显式调用 `set_render_backend`。此库不会自动读取同名环境变量或 Django settings。
+
+| 配置 | 默认值 | 行为 |
+| --- | --- | --- |
+| `MAKO_RENDER_BACKEND` | `inprocess` | `subprocess` 启用子进程后端 |
+| `MAKO_RENDER_POOL_SIZE` | 4 | 同时占用的槽位及监督线程上限 |
+| `MAKO_RENDER_MAX_USES` | 500 | 每个 worker 的复用次数；达到后回收，下次请求再创建 |
+| `MAKO_RENDER_TIMEOUT` | 30 秒 | 排队、准备、启动、握手、发送、渲染和接收共享的时间预算 |
+| `MAKO_RENDER_FALLBACK_INPROCESS` | False | 仅主进程确认 context/spec 不可移植时，允许显式兼容回退 |
+| `MAKO_RENDER_NO_NETWORK` | True | 必须成功创建 Linux network namespace，否则不发送业务 context、不渲染 |
+| `MAKO_RENDER_OS_HARDEN` | True | Linux core/CPU/地址空间的资源限制，与无网络要求分别生效 |
+| `MAKO_RENDER_RLIMIT_CPU` | 30 秒 | worker 累计 CPU 时间上限（并非每次请求重置） |
+| `MAKO_RENDER_RLIMIT_AS_MB` | 1024 MB | worker 地址空间上限 |
+
+使用示例（测试环境显式允许联网；不代表已建立无网络边界）：
+
+```python
+from bamboo_engine.template.render_backend import SubprocessPoolRenderBackend, set_render_backend
+
+set_render_backend(SubprocessPoolRenderBackend(pool_size=2, timeout=10, no_network=False))
+```
+
+## 故障行为
+
+- 默认返回原始模板字符串，与既有渲染失败行为一致。
+- 无 spec 同样服从 strict 配置。网络隔离失败、启动失败、通信异常、协议损坏、超时均不触发进程内回退。
+- 时间预算覆盖阻塞的进程启动：每个槽位由一个持久监督线程负责。调用超时可先返回；尚未结束的启动仍占用原槽位，启动完成后回收，避免不断创建后台启动线程。所有槽位占满时，后续调用在预算内返回。
+- 成功结果先返回，回收不再同步创建替代 worker。启动失败后保留槽位，下一次调用可以重试。
+- POSIX 上使用独立 Python 解释器，可由 daemon/prefork 宿主启动；不重新导入宿主 `__main__`。fork 后重建本地池，只关闭继承的父进程连接副本。
+- 回收使用独立进程组强杀；Linux worker 设置父线程死亡信号。监督线程与 worker 生命周期一致。宿主正常退出或关闭后端会回收 worker。
+
+## Context 契约
+
+请求来自受信任的服务端对象构造过程，以单向 pickle 发送。**这不是接收外部 pickle 的接口，也不能把任意不可信 Python 对象当作安全输入。**模板必须是普通字符串，spec 仅允许已知 flavor 和字符串配置，context 顶层键必须为普通字符串。
+
+普通标量与容器递归保留；显式保留 `time.struct_time`、`Counter`、`Decimal`、日期/时间等支持类型。包含 property、公共方法或继承行为的未知对象、未知容器子类（包括自定义 namedtuple）会被明确判为不支持；不会先降级为 tuple/dict/属性包后再静默渲染错误。仅没有上述行为的结构化属性包转换为 `PortableRenderObject`，保留实例属性和受信任对象的字符串表示。受信任宿主注入的可导入函数可按引用传输，其模块可能加载应用代码。
+
+对象图最多 8 层、100000 个元素、累计 8 MiB 字符/字节内容，整数最多 4096 bit；拒绝环。请求/回复帧分别最多 8 MiB（包括编码开销）。超出支持范围需要按日志回归，不能据此声称开启 subprocess 对所有历史 Python 对象语义均无影响。
+
+worker 回复采用版本、请求 ID、状态和字符串结果组成的受限 JSON，主进程不反序列化 worker pickle。接收前校验帧长度，并校验字段类型、数字、版本和请求 ID；损坏回复会销毁 worker。
+
+显式 `fallback_inprocess=True` 会让不支持的数据重新进入宿主渲染，只适合受信任兼容验证；回退本身不具备隔离后端的资源或安全保证。保持默认 strict 可以避免这条自动回退路径。
+
+## 隔离边界与验证范围
+
+解释器启动前应用环境变量白名单、关闭无关文件描述符并禁用 site 启动钩子。无网络要求在非 Linux 或权限不足（例如 EPERM）时失败关闭。启用 Linux 资源限制时，同时降低 soft/hard 上限。
+
+该后端**不等同于无凭证容器沙箱**：仍共享宿主身份/文件系统，context、导入模块、挂载文件和路径型 Unix socket 可能暴露资源。Python 导入路径与模块配置必须由宿主信任。进程组不约束恶意主动脱组的后代，仍需部署层权限、文件系统、cgroup 等隔离。warm worker 复用也不提供不同请求间的强隔离；已被攻破的进程可能保留状态。`max_uses=1` 可关闭请求间复用，但不替代上述部署层隔离。
+
+本地库级测试不能代替目标 Linux 容器权限检查、Celery 部署验证及业务流程回归。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-engine"
-version = "2.6.5"
+version = "2.6.6"
 description = "Bamboo-engine is a general-purpose workflow engine"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"

--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "3.24.16"
+__version__ = "3.24.17"

--- a/runtime/bamboo-pipeline/pipeline/conf/default_settings.py
+++ b/runtime/bamboo-pipeline/pipeline/conf/default_settings.py
@@ -88,7 +88,53 @@ EXPIRED_TASK_CLEAN_NUM_LIMIT = getattr(settings, "EXPIRED_TASK_CLEAN_NUM_LIMIT",
 TASK_EXPIRED_MONTH = getattr(settings, "TASK_EXPIRED_MONTH", 6)
 
 # MAKO sandbox config
-MAKO_SANDBOX_SHIELD_WORDS = getattr(settings, "MAKO_SANDBOX_SHIELD_WORDS", [])
+# 默认屏蔽所有可被用于 SSTI 链路的内建可调用名字（getattr/eval/exec/open/type/__import__ 等）。
+# 这是一份与 ``bamboo_engine.config.Settings.MAKO_SANDBOX_SHIELD_WORDS`` 保持同步的安全兜底，
+# 任何未显式设置 ``MAKO_SANDBOX_SHIELD_WORDS`` 的 Django 宿主也能开箱即得到屏蔽。
+DEFAULT_MAKO_SANDBOX_SHIELD_WORDS = [
+    "ascii",
+    "breakpoint",
+    "bytearray",
+    "bytes",
+    "callable",
+    "chr",
+    "classmethod",
+    "compile",
+    "delattr",
+    "dir",
+    "divmod",
+    "exec",
+    "eval",
+    "filter",
+    "format",
+    "frozenset",
+    "getattr",
+    "globals",
+    "hasattr",
+    "hash",
+    "help",
+    "id",
+    "input",
+    "isinstance",
+    "issubclass",
+    "iter",
+    "locals",
+    "map",
+    "memoryview",
+    "next",
+    "object",
+    "open",
+    "print",
+    "property",
+    "repr",
+    "setattr",
+    "staticmethod",
+    "super",
+    "type",
+    "vars",
+    "__import__",
+]
+MAKO_SANDBOX_SHIELD_WORDS = getattr(settings, "MAKO_SANDBOX_SHIELD_WORDS", DEFAULT_MAKO_SANDBOX_SHIELD_WORDS)
 MAKO_SANDBOX_IMPORT_MODULES = getattr(settings, "MAKO_SANDBOX_IMPORT_MODULES", {})
 MAKO_SAFETY_CHECK = getattr(settings, "MAKO_SAFETY_CHECK", True)
 

--- a/runtime/bamboo-pipeline/pipeline/core/data/expression.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/expression.py
@@ -141,6 +141,26 @@ class ConstantTemplate(object):
                 except Exception:
                     logger.exception("{} safety check error.".format(tpl))
                     continue
+                # 根标识符白名单（``MAKO_TEMPLATE_NAME_WHITELIST_MODE``），延用引擎全局
+                # ``Settings`` 配置；off 时保持历史行为，warn 仅打日志，enforce 命中即
+                # 按 SingleLineNodeVisitor 风格 inert 掉这一段模板。
+                from bamboo_engine.config import Settings as _BambooSettings
+
+                whitelist_mode = getattr(_BambooSettings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", "off")
+                if whitelist_mode in ("warn", "enforce"):
+                    allowed_names = mako_safety.build_allowed_names(value_maps)
+                    try:
+                        check_mako_template_safety(
+                            tpl,
+                            mako_safety.WhitelistNameVisitor(allowed_names, mode=whitelist_mode),
+                            mako_safety.SingleLinCodeExtractor(),
+                        )
+                    except ForbiddenMakoTemplateException as e:
+                        logger.warning("forbidden by whitelist: {}, exception: {}".format(tpl, e))
+                        continue
+                    except Exception:
+                        logger.exception("{} whitelist check error.".format(tpl))
+                        continue
             resolved = ConstantTemplate.resolve_template(tpl, value_maps)
             string = string.replace(tpl, resolved)
         return string

--- a/runtime/bamboo-pipeline/pipeline/core/data/expression.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/expression.py
@@ -19,6 +19,7 @@ from mako.template import Template
 from mako import lexer, codegen
 from mako.exceptions import MakoException
 
+from bamboo_engine.template.sandbox import harden_template_builtins
 from pipeline import exceptions
 from pipeline.conf.default_settings import MAKO_SAFETY_CHECK
 from pipeline.core.data.sandbox import SANDBOX
@@ -177,6 +178,7 @@ class ConstantTemplate(object):
         except (MakoException, SyntaxError) as e:
             logger.error("pipeline resolve template[{}] error[{}]".format(template, e))
             return template
+        harden_template_builtins(tm)
         try:
             resolved = tm.render_unicode(**data)
         except Exception as e:

--- a/runtime/bamboo-pipeline/pipeline/core/data/expression.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/expression.py
@@ -15,13 +15,12 @@ import copy
 import re
 import logging
 
-from mako.template import Template
 from mako import lexer, codegen
 from mako.exceptions import MakoException
 
-from bamboo_engine.template.sandbox import harden_template_builtins
+from bamboo_engine.template.render_backend import get_render_backend, SandboxProvider, SandboxSpec
 from pipeline import exceptions
-from pipeline.conf.default_settings import MAKO_SAFETY_CHECK
+from pipeline.conf.default_settings import MAKO_SAFETY_CHECK, MAKO_SANDBOX_SHIELD_WORDS, MAKO_SANDBOX_IMPORT_MODULES
 from pipeline.core.data.sandbox import SANDBOX
 from pipeline.core.data import mako_safety
 from pipeline.utils.mako_utils.checker import check_mako_template_safety
@@ -31,6 +30,18 @@ from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 logger = logging.getLogger("root")
 # find mako template(format is ${xxx}，and ${}# not in xxx, # may raise memory error)
 TEMPLATE_PATTERN = re.compile(r"\${[^$#]+}")
+
+
+def _mako_render_sandbox():
+    """render backend 的 sandbox_builder：在调用时读取本模块的 ``SANDBOX`` 全局。
+
+    与历史实现 ``data.update(SANDBOX)`` 的语义严格一致——都以 *expression 模块此刻绑定的*
+    ``SANDBOX`` 为准。这一点很关键：部分测试会 ``sandbox.SANDBOX = deepcopy(...)`` 重新绑定
+    ``pipeline.core.data.sandbox`` 的全局，但历史渲染读的始终是 expression 侧捕获的对象，因此
+    这里也必须读 expression 的 ``SANDBOX``，而不是 ``pipeline.core.data.sandbox`` 的实时全局，
+    否则会在 rebind 后与历史行为分叉。该函数为模块级函数，可被隔离 backend 跨进程引用。
+    """
+    return SANDBOX
 
 
 def format_constant_key(key):
@@ -168,21 +179,14 @@ class ConstantTemplate(object):
 
     @staticmethod
     def resolve_template(template, value_maps):
-        data = {}
-        data.update(SANDBOX)
-        data.update(value_maps)
         if not isinstance(template, str):
             raise exceptions.ConstantTypeException("constant resolve error, template[%s] is not a string" % template)
-        try:
-            tm = Template(template)
-        except (MakoException, SyntaxError) as e:
-            logger.error("pipeline resolve template[{}] error[{}]".format(template, e))
-            return template
-        harden_template_builtins(tm)
-        try:
-            resolved = tm.render_unicode(**data)
-        except Exception as e:
-            logger.warning("constant content({}) is invalid, data({}), error: {}".format(template, data, e))
-            return template
-        else:
-            return resolved
+        # 与 ``bamboo_engine.template.template.Template._render_template`` 对齐：唯一的“执行用户
+        # 表达式”入口下沉到可插拔 render backend，默认行为完全不变。provider 同时提供：进程内
+        # ``_mako_render_sandbox`` 现场取沙箱（mock builtins + shield + 注入模块），与可序列化的
+        # ``SandboxSpec``（legacy flavor，供隔离 backend 在子进程本地重建沙箱、只序列化 value_maps）。
+        provider = SandboxProvider(
+            _mako_render_sandbox,
+            SandboxSpec("legacy", MAKO_SANDBOX_SHIELD_WORDS, MAKO_SANDBOX_IMPORT_MODULES),
+        )
+        return get_render_backend().render(template, value_maps, provider)

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -17,6 +17,7 @@ import re
 from mako import parsetree
 
 from bamboo_engine.utils.mako_safety import (
+    FRAME_INTROSPECTION_ATTRS,
     configured_import_aliases,
     import_chain_violation,
     resolve_attr_chain,
@@ -146,6 +147,8 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FRAME_INTROSPECTION_ATTRS:
+            raise ForbiddenMakoTemplateException("can not access frame or generator internals")
         if node.attr in FORBIDDEN_TEMPLATE_METHODS:
             raise ForbiddenMakoTemplateException("can not call forbidden method")
         self.generic_visit(node)
@@ -298,6 +301,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
             return
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
+            return
+        if node.attr in FRAME_INTROSPECTION_ATTRS:
+            self._violate(node.attr, "frame or generator internals")
             return
         kind, root, attrs = resolve_attr_chain(node)
         if kind == "name" and root in MAKO_RESERVED_NAMESPACES:

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -149,8 +149,16 @@ class SingleLineNodeVisitor(ast.NodeVisitor):
             raise ForbiddenMakoTemplateException("can not access private attribute")
         if node.attr in FRAME_INTROSPECTION_ATTRS:
             raise ForbiddenMakoTemplateException("can not access frame or generator internals")
+        # 与 ``bamboo_engine.utils.mako_safety.SingleLineNodeVisitor`` 对齐：危险属性名与保留
+        # 命名空间属性链下沉为 always-on 无条件拦截，堵住 off 模式下的模块反向 pivot 与
+        # ``self.module...`` 链路。
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            raise ForbiddenMakoTemplateException("can not access dangerous attribute")
         if node.attr in FORBIDDEN_TEMPLATE_METHODS:
             raise ForbiddenMakoTemplateException("can not call forbidden method")
+        root_kind, root_name, _attrs = resolve_attr_chain(node)
+        if root_kind == "name" and root_name in MAKO_RESERVED_NAMESPACES:
+            raise ForbiddenMakoTemplateException("can not access mako reserved namespace attribute")
         self.generic_visit(node)
 
     def visit_Name(self, node):

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -16,6 +16,11 @@ import re
 
 from mako import parsetree
 
+from bamboo_engine.utils.mako_safety import (
+    configured_import_aliases,
+    import_chain_violation,
+    resolve_attr_chain,
+)
 from pipeline.utils.mako_utils.code_extract import MakoNodeCodeExtractor
 from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
@@ -283,20 +288,26 @@ class WhitelistNameVisitor(ast.NodeVisitor):
         if not isinstance(node.ctx, ast.Load):
             return
         if node.id in MAKO_RESERVED_NAMESPACES:
-            self._violate(node.id, "mako reserved namespace")
             return
         if not self._name_allowed(node.id):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
-        # 与新引擎 ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor.visit_Attribute``
-        # 保持一致：单下划线前缀 + 危险 attr 名一律拒绝，堵反向引用 SSTI 链路。
-        if node.attr.startswith("_"):
+        if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return
         if node.attr in DANGEROUS_ATTR_NAMES:
             self._violate(node.attr, "dangerous attribute")
             return
+        kind, root, attrs = resolve_attr_chain(node)
+        if kind == "name" and root in MAKO_RESERVED_NAMESPACES:
+            self._violate(root, "mako reserved namespace attribute")
+            return
+        if kind == "name":
+            reason = import_chain_violation(root, attrs, configured_import_aliases())
+            if reason:
+                self._violate(root, reason)
+                return
         self.generic_visit(node)
 
     def _enter_comprehension(self, node):

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -10,8 +10,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-from ast import NodeVisitor
+import ast
+import logging
+import re
 
 from mako import parsetree
 
@@ -19,7 +20,103 @@ from pipeline.utils.mako_utils.code_extract import MakoNodeCodeExtractor
 from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
-class SingleLineNodeVisitor(NodeVisitor):
+logger = logging.getLogger("root")
+
+# 与 ``MAKO_SANDBOX_SHIELD_WORDS`` 不重叠的"安全内建函数"集合，详见
+# ``bamboo_engine.utils.mako_safety.SAFE_BUILTIN_NAMES``。
+SAFE_BUILTIN_NAMES = frozenset(
+    {
+        "True",
+        "False",
+        "None",
+        "bool",
+        "int",
+        "float",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        "abs",
+        "round",
+        "pow",
+        "sum",
+        "min",
+        "max",
+        "len",
+        "range",
+        "slice",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        "all",
+        "any",
+    }
+)
+
+# Mako 渲染期保留命名空间，详见 ``bamboo_engine.utils.mako_safety.MAKO_RESERVED_NAMESPACES``。
+MAKO_RESERVED_NAMESPACES = frozenset(
+    {
+        "self",
+        "context",
+        "local",
+        "parent",
+        "next",
+        "caller",
+        "pageargs",
+        "UNDEFINED",
+        "STOP_RENDERING",
+    }
+)
+
+# attr 链路危险字段，详见 ``bamboo_engine.utils.mako_safety.DANGEROUS_ATTR_NAMES``。
+DANGEROUS_ATTR_NAMES = frozenset(
+    {
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "ctypes",
+        "socket",
+        "_thread",
+        "threading",
+        "builtins",
+        "__builtins__",
+        "modules",
+        "popen",
+        "popen2",
+        "popen3",
+        "popen4",
+        "system",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "fork",
+        "forkpty",
+        "kill",
+    }
+)
+
+FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
+SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class SingleLineNodeVisitor(ast.NodeVisitor):
     """
     遍历语法树节点，遇到魔术方法使用或 import 时，抛出异常
     """
@@ -27,19 +124,72 @@ class SingleLineNodeVisitor(NodeVisitor):
     def __init__(self, *args, **kwargs):
         super(SingleLineNodeVisitor, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def _get_subscript_key(node):
+        slice_node = node.slice
+        constant_node = getattr(ast, "Constant", None)
+        if (
+            constant_node is not None
+            and isinstance(slice_node, constant_node)
+            and isinstance(slice_node.value, str)
+        ):
+            return slice_node.value
+        if hasattr(ast, "Str") and isinstance(slice_node, ast.Str):
+            return slice_node.s
+        return None
+
     def visit_Attribute(self, node):
         if node.attr.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private attribute")
+        if node.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Name(self, node):
         if node.id.startswith("__"):
             raise ForbiddenMakoTemplateException("can not access private method")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        subscript_key = self._get_subscript_key(node)
+        if isinstance(subscript_key, str) and subscript_key.startswith("__"):
+            raise ForbiddenMakoTemplateException("can not access private key")
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_TEMPLATE_METHODS:
+            raise ForbiddenMakoTemplateException("can not call forbidden method")
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         raise ForbiddenMakoTemplateException("can not use import statement")
 
     def visit_ImportFrom(self, node):
         self.visit_Import(node)
+
+
+def validate_filter_args(filter_args):
+    """对 ``${expr | filter}`` 与 tag-level ``filter=`` 的 filter callable 做白名单校验。
+
+    Mako 在渲染期会把 filter 表达式作为 Python 代码 ``eval`` 出 callable，因此必须在
+    parse 阶段就拒绝任意 Python 表达式，否则攻击者可以通过 ``(side_effect() or str)``
+    这种 filter 表达式绕过主表达式上的 AST 检查。
+    """
+
+    for filter_arg in filter_args:
+        normalized_filter = filter_arg.strip()
+        if not normalized_filter:
+            continue
+        if normalized_filter in SAFE_FILTERS:
+            continue
+        decode_filter_parts = normalized_filter.split(".")
+        if (
+            SAFE_DECODE_FILTER_PATTERN.match(normalized_filter)
+            and "__" not in normalized_filter
+            and not any(part.startswith("_") for part in decode_filter_parts[1:])
+        ):
+            continue
+        raise ForbiddenMakoTemplateException("unsupported filter expression: [{}]".format(normalized_filter))
 
 
 class SingleLinCodeExtractor(MakoNodeCodeExtractor):
@@ -50,3 +200,139 @@ class SingleLinCodeExtractor(MakoNodeCodeExtractor):
             return None
         else:
             raise ForbiddenMakoTemplateException("Unsupported node: [{}]".format(node.__class__.__name__))
+
+
+def _deformat_var_key(key):
+    """``${name}`` -> ``name``；其它 key 原样返回。"""
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def build_allowed_names(context, *, extra=()):
+    """legacy 模板渲染白名单根标识符集合。
+
+    与 ``bamboo_engine.utils.mako_safety.build_allowed_names`` 行为一致：
+    复用 ``bamboo_engine.config.Settings`` 上的 ``MAKO_SANDBOX_IMPORT_MODULES /
+    MAKO_TEMPLATE_NAME_EXTRA_WHITELIST`` 配置，避免接入方维护两套白名单源。
+    """
+    from bamboo_engine.config import Settings
+
+    allowed = set(SAFE_BUILTIN_NAMES)
+
+    for key in context.keys() if context else ():
+        allowed.add(_deformat_var_key(key))
+
+    import_modules = getattr(Settings, "MAKO_SANDBOX_IMPORT_MODULES", None) or {}
+    for alias in import_modules.values():
+        if alias:
+            allowed.add(alias.split(".", 1)[0])
+
+    extra_whitelist = getattr(Settings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", None) or ()
+    allowed.update(extra_whitelist)
+    allowed.update(extra)
+
+    return allowed
+
+
+class WhitelistNameVisitor(ast.NodeVisitor):
+    """legacy 渲染路径用的白名单 visitor，行为对齐
+    ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor``。
+    """
+
+    def __init__(self, allowed_names, mode="enforce", on_violation=None):
+        if mode not in {"warn", "enforce"}:
+            raise ValueError("invalid whitelist mode: {}".format(mode))
+        self.allowed_names = set(allowed_names)
+        self.mode = mode
+        self.on_violation = on_violation
+        self.scope_stack = []
+
+    def _name_allowed(self, name):
+        if name in MAKO_RESERVED_NAMESPACES:
+            return False
+        if name in self.allowed_names:
+            return True
+        for scope in self.scope_stack:
+            if name in scope:
+                return True
+        return False
+
+    def _violate(self, name, reason):
+        msg = "name not in whitelist: {} ({})".format(name, reason)
+        if self.on_violation is not None:
+            try:
+                self.on_violation(name, reason)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("on_violation callback raised")
+        if self.mode == "enforce":
+            raise ForbiddenMakoTemplateException(msg)
+        logger.warning("[mako_whitelist] %s", msg)
+
+    @staticmethod
+    def _collect_targets(target, into):
+        if isinstance(target, ast.Name):
+            into.add(target.id)
+        elif isinstance(target, ast.Starred):
+            WhitelistNameVisitor._collect_targets(target.value, into)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                WhitelistNameVisitor._collect_targets(elt, into)
+
+    def visit_Name(self, node):
+        if not isinstance(node.ctx, ast.Load):
+            return
+        if node.id in MAKO_RESERVED_NAMESPACES:
+            self._violate(node.id, "mako reserved namespace")
+            return
+        if not self._name_allowed(node.id):
+            self._violate(node.id, "not in whitelist")
+
+    def visit_Attribute(self, node):
+        # 与新引擎 ``bamboo_engine.utils.mako_safety.WhitelistNameVisitor.visit_Attribute``
+        # 保持一致：单下划线前缀 + 危险 attr 名一律拒绝，堵反向引用 SSTI 链路。
+        if node.attr.startswith("_"):
+            self._violate(node.attr, "private attribute")
+            return
+        if node.attr in DANGEROUS_ATTR_NAMES:
+            self._violate(node.attr, "dangerous attribute")
+            return
+        self.generic_visit(node)
+
+    def _enter_comprehension(self, node):
+        local = set()
+        for gen in node.generators:
+            self._collect_targets(gen.target, local)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()
+
+    def visit_ListComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_SetComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_DictComp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_GeneratorExp(self, node):
+        self._enter_comprehension(node)
+
+    def visit_Lambda(self, node):
+        local = set()
+        args = node.args
+        local.update(arg.arg for arg in args.args)
+        local.update(arg.arg for arg in args.kwonlyargs)
+        local.update(arg.arg for arg in getattr(args, "posonlyargs", ()) or ())
+        if args.vararg:
+            local.add(args.vararg.arg)
+        if args.kwarg:
+            local.add(args.kwarg.arg)
+        self.scope_stack.append(local)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.scope_stack.pop()

--- a/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/mako_safety.py
@@ -117,7 +117,8 @@ DANGEROUS_ATTR_NAMES = frozenset(
     }
 )
 
-FORBIDDEN_TEMPLATE_METHODS = {"format", "format_map"}
+# .format 保留 off/warn 下的存量兼容，仅 enforce 检查；format_map 仍始终拒绝。
+FORBIDDEN_TEMPLATE_METHODS = {"format_map"}
 SAFE_FILTERS = {"n", "h", "x", "u", "trim", "entity", "unicode", "str"}
 SAFE_DECODE_FILTER_PATTERN = re.compile(r"^decode\.[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
@@ -304,6 +305,9 @@ class WhitelistNameVisitor(ast.NodeVisitor):
             self._violate(node.id, "not in whitelist")
 
     def visit_Attribute(self, node):
+        if self.mode == "enforce" and node.attr == "format":
+            self._violate(node.attr, "forbidden method")
+            return
         if node.attr.startswith("__"):
             self._violate(node.attr, "private attribute")
             return

--- a/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
 # mock str return value of Built-in Functions，make str(func) return "func" rather than "<built-in function func>"
 
 import builtins
-import importlib
 
+from bamboo_engine.template.sandbox import resolve_import_object
 from pipeline.conf import default_settings
 
 SANDBOX = {}
@@ -48,13 +48,18 @@ class ModuleObject:
 
 
 def _import_modules(sandbox, modules):
-    for mod_path, alias in modules.items():
-        mod = importlib.import_module(mod_path)
+    items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
+    for mod_path, alias in items:
+        obj = resolve_import_object(mod_path)
         sub_paths = alias.split(".")
         if len(sub_paths) == 1:
-            sandbox[alias] = mod
-        else:
-            sandbox[sub_paths[0]] = ModuleObject(sub_paths[1:], mod)
+            sandbox[alias] = obj
+            continue
+        root = sub_paths[0]
+        existing = sandbox.get(root)
+        if existing is not None and not isinstance(existing, ModuleObject):
+            continue
+        sandbox[root] = ModuleObject(sub_paths[1:], obj)
 
 
 def _mock_builtins():

--- a/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
 
 import builtins
 
-from bamboo_engine.template.sandbox import resolve_import_object
+from bamboo_engine.template.sandbox import filter_import_modules, resolve_import_object
 from pipeline.conf import default_settings
 
 SANDBOX = {}
@@ -48,6 +48,7 @@ class ModuleObject:
 
 
 def _import_modules(sandbox, modules):
+    modules = filter_import_modules(modules)
     items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
     for mod_path, alias in items:
         obj = resolve_import_object(mod_path)

--- a/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/sandbox.py
@@ -12,69 +12,40 @@ specific language governing permissions and limitations under the License.
 """
 
 # mock str return value of Built-in Functions，make str(func) return "func" rather than "<built-in function func>"
+#
+# 渲染沙箱的构造原语已下沉到 Django-free 的 ``pipeline.core.data.sandbox_builder``，使无网无凭证的
+# 隔离渲染子进程能复用**同一套**构造逻辑重建沙箱（不必 import Django / 业务 app / 凭证）。本模块保留
+# Django 侧入口（读 settings、维护进程内全局 ``SANDBOX``）与历史向后兼容符号
+# （``MockStrMeta`` / ``_shield_words`` / ``_import_modules`` / ``ModuleObject``）。
 
-import builtins
-
-from bamboo_engine.template.sandbox import filter_import_modules, resolve_import_object
+from pipeline.core.data import sandbox_builder
 from pipeline.conf import default_settings
 
 SANDBOX = {}
 
+# 向后兼容原语：re-export Django-free 实现，保证进程内构造与隔离 worker 重建同源、不漂移。
+ModuleObject = sandbox_builder.ModuleObject
+_shield_words = sandbox_builder.shield_words
+_import_modules = sandbox_builder.import_modules
 
-class MockStrMeta(type):
+
+class MockStrMeta(sandbox_builder.MockStrMeta):
+    """历史 ``MockStrMeta``：动态定义 mock 类时自动注册进模块级 ``SANDBOX``。
+
+    外部代码与既有测试依赖这一副作用，故保留；``__str__`` / ``__call__`` 复用
+    ``sandbox_builder.MockStrMeta``，此处仅额外维持全局注册行为。
+    """
+
     def __new__(cls, name, bases, attrs):
-        new_cls = super(MockStrMeta, cls).__new__(cls, name, bases, attrs)
+        new_cls = super().__new__(cls, name, bases, attrs)
         SANDBOX.update({new_cls.str_return: new_cls})
         return new_cls
 
-    def __str__(cls):
-        return cls.str_return
 
-    def __call__(cls, *args, **kwargs):
-        return cls.call(*args, **kwargs)
-
-
-def _shield_words(sandbox, words):
-    for shield_word in words:
-        sandbox[shield_word] = None
-
-
-class ModuleObject:
-    def __init__(self, sub_paths, module):
-        if len(sub_paths) == 1:
-            setattr(self, sub_paths[0], module)
-            return
-        setattr(self, sub_paths[0], ModuleObject(sub_paths[1:], module))
-
-
-def _import_modules(sandbox, modules):
-    modules = filter_import_modules(modules)
-    items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
-    for mod_path, alias in items:
-        obj = resolve_import_object(mod_path)
-        sub_paths = alias.split(".")
-        if len(sub_paths) == 1:
-            sandbox[alias] = obj
-            continue
-        root = sub_paths[0]
-        existing = sandbox.get(root)
-        if existing is not None and not isinstance(existing, ModuleObject):
-            continue
-        sandbox[root] = ModuleObject(sub_paths[1:], obj)
-
-
-def _mock_builtins():
-    """
-    @summary: generate mock class of built-in functions like id,int
-    """
-    for func_name in dir(builtins):
-        if func_name.lower() == func_name and not func_name.startswith("_"):
-            new_func_name = "Mock{}".format(func_name.capitalize())
-            MockStrMeta(new_func_name, (object,), {"call": getattr(builtins, func_name), "str_return": func_name})
-
-
-_mock_builtins()
-
-_shield_words(SANDBOX, default_settings.MAKO_SANDBOX_SHIELD_WORDS)
-
-_import_modules(SANDBOX, default_settings.MAKO_SANDBOX_IMPORT_MODULES)
+# 进程内渲染沙箱：委托同源 Django-free builder 构造，仅在此读取 Django settings。
+SANDBOX.update(
+    sandbox_builder.build_sandbox(
+        default_settings.MAKO_SANDBOX_SHIELD_WORDS,
+        default_settings.MAKO_SANDBOX_IMPORT_MODULES,
+    )
+)

--- a/runtime/bamboo-pipeline/pipeline/core/data/sandbox_builder.py
+++ b/runtime/bamboo-pipeline/pipeline/core/data/sandbox_builder.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+# 渲染沙箱构造原语（Django-free）。
+#
+# 目的：把「构造 legacy 渲染沙箱命名空间」这件事与 Django settings 彻底解耦，使其可以在一个
+# **精简、无网、无凭证的隔离渲染子进程**里被重建——子进程只需 import 本模块 + bamboo_engine
+# 的沙箱原语，而**不必** import ``pipeline.conf`` / Django / 业务 app（那会把平台密钥、DB/ESB
+# 凭证重新带回子进程，破坏隔离承诺）。
+#
+# 与历史 ``pipeline.core.data.sandbox`` 的构造语义严格等价：
+#   * mock builtins：``str(int) -> "int"``、``int("3") -> 3``（模板里 ``${int}`` 打印成名字）；
+#   * shield words：把危险名在命名空间里置 None；
+#   * import modules：按别名注入模块 / ModuleObject 链，并复用 bamboo_engine 的注入 deny-list。
+#
+# 关键区别：本模块**不依赖任何模块级全局**，``build_sandbox`` 每次返回全新 dict，天然规避跨渲染
+# 状态泄漏——这正是隔离 worker「每次 render 拿到 pristine 命名空间」所需要的。
+
+import builtins
+
+from bamboo_engine.template.sandbox import filter_import_modules, resolve_import_object
+
+
+class MockStrMeta(type):
+    """使内建函数代理类的 ``str(cls)`` 返回原名、``cls(...)`` 调用真实内建。
+
+    与历史实现不同：这里**不**在 ``__new__`` 里写任何模块级全局，构造过程全部落在传入的 dict 上，
+    保证 Django-free 且无副作用。
+    """
+
+    def __str__(cls):
+        return cls.str_return
+
+    def __call__(cls, *args, **kwargs):
+        return cls.call(*args, **kwargs)
+
+
+def make_mock_builtin(func_name):
+    """为单个内建名生成一个 :class:`MockStrMeta` 代理类。"""
+    new_func_name = "Mock{}".format(func_name.capitalize())
+    return MockStrMeta(new_func_name, (object,), {"call": getattr(builtins, func_name), "str_return": func_name})
+
+
+def add_mock_builtins(sandbox):
+    """把安全内建（小写、非 ``_`` 开头）的 mock 代理类注入 ``sandbox``。"""
+    for func_name in dir(builtins):
+        if func_name.lower() == func_name and not func_name.startswith("_"):
+            cls = make_mock_builtin(func_name)
+            sandbox[cls.str_return] = cls
+    return sandbox
+
+
+def shield_words(sandbox, words):
+    """把 ``words`` 中的每个名字在 ``sandbox`` 里置 None（渲染期取用即失败）。"""
+    for shield_word in words or []:
+        sandbox[shield_word] = None
+    return sandbox
+
+
+class ModuleObject:
+    def __init__(self, sub_paths, module):
+        if len(sub_paths) == 1:
+            setattr(self, sub_paths[0], module)
+            return
+        setattr(self, sub_paths[0], ModuleObject(sub_paths[1:], module))
+
+
+def import_modules(sandbox, modules):
+    """按别名把 ``modules`` 注入 ``sandbox``；复用 bamboo_engine 的注入 deny-list 兜底。"""
+    modules = filter_import_modules(modules or {})
+    items = sorted(modules.items(), key=lambda kv: kv[1].count("."))
+    for mod_path, alias in items:
+        obj = resolve_import_object(mod_path)
+        sub_paths = alias.split(".")
+        if len(sub_paths) == 1:
+            sandbox[alias] = obj
+            continue
+        root = sub_paths[0]
+        existing = sandbox.get(root)
+        if existing is not None and not isinstance(existing, ModuleObject):
+            continue
+        sandbox[root] = ModuleObject(sub_paths[1:], obj)
+    return sandbox
+
+
+def build_sandbox(shield, imports):
+    """从（shield_words, import_modules）配置构造一个全新的 legacy 渲染沙箱命名空间。
+
+    :param shield: 需要在命名空间里置 None 的危险名列表
+    :param imports: ``{模块路径: 别名}`` 注入表
+    :return: 全新 dict（mock builtins + shields + 注入模块）
+    """
+    sandbox = {}
+    add_mock_builtins(sandbox)
+    shield_words(sandbox, shield)
+    import_modules(sandbox, imports)
+    return sandbox

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -275,16 +275,43 @@ class TestMakoNameWhitelist(TestCase):
         finally:
             self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
 
-    def test_single_underscore_attr_blocked(self):
+    def test_reserved_namespace_attributes_blocked(self):
         self._set_mode("enforce")
         for p in [
             "${context._kwargs}",
             "${context._with_template}",
-            "${obj._secret}",
         ]:
             with self.subTest(payload=p):
-                rendered = expression.ConstantTemplate(p).resolve_data({"obj": object()})
+                rendered = expression.ConstantTemplate(p).resolve_data({})
                 self.assertEqual(rendered, p)
+
+    def test_user_single_underscore_attr_allowed(self):
+        self._set_mode("enforce")
+
+        class Bag(object):
+            def __init__(self):
+                self._module = [{"gamesvr": "1.1.1.1"}]
+
+        rendered = expression.ConstantTemplate("${obj._module[0]['gamesvr']}").resolve_data({"obj": Bag()})
+        self.assertEqual(rendered, "1.1.1.1")
+
+    def test_bare_caller_allowed(self):
+        self._set_mode("enforce")
+        # ConstantTemplate 对光杆 ``${caller}`` 会按 context 键短路，AST 走不到 visitor。
+        self.assertEqual(
+            expression.ConstantTemplate("${parent + ''}").resolve_data({"parent": "alice"}),
+            "alice",
+        )
+
+    def test_import_deep_chain_blocked(self):
+        self._set_mode("enforce")
+        original = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {"json": "json"}
+        try:
+            payload = "${json.codecs.builtins.exec('1')}"
+            self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original
 
     def test_business_patterns_still_render(self):
         self._set_mode("enforce")

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -236,11 +236,13 @@ class TestMakoNameWhitelist(TestCase):
         self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
         self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
 
-    def test_off_mode_keeps_legacy_behavior(self):
+    def test_off_mode_also_blocks_self_module(self):
+        # 保留命名空间属性链下沉 always-on 后，off 模式也 inert
+        # （此前 off 会解析出真实 os 模块执行命令，这里回归为拦截）。
         self._set_mode("off")
         payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
         rendered = expression.ConstantTemplate(payload).resolve_data({})
-        self.assertIn("OFF", rendered)
+        self.assertEqual(rendered, payload)
 
     def test_default_mode_blocks_self_module(self):
         payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
@@ -345,6 +347,36 @@ class TestMakoNameWhitelist(TestCase):
                 self._set_mode(mode)
                 self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
 
+    def test_dangerous_attr_chain_blocked_all_modes(self):
+        # 危险属性名下沉 always-on 后，模块反向 pivot 在 off / warn / enforce 三档都 inert。
+        original_imports = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {
+            "datetime": "datetime",
+            "re": "re",
+            "os.path": "os.path",
+            "json": "json",
+        }
+        payloads = [
+            '${os.path.os.system("echo PWNED")}',
+            '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+            '${json.codecs.builtins.exec("import os")}',
+        ]
+        try:
+            for mode in ("off", "warn", "enforce"):
+                for p in payloads:
+                    with self.subTest(mode=mode, payload=p):
+                        self._set_mode(mode)
+                        self.assertEqual(expression.ConstantTemplate(p).resolve_data({}), p)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+    def test_reserved_namespace_chain_blocked_all_modes(self):
+        for mode in ("off", "warn", "enforce"):
+            for p in ("${context.lookup}", "${local.something}", "${parent.foo}"):
+                with self.subTest(mode=mode, payload=p):
+                    self._set_mode(mode)
+                    self.assertEqual(expression.ConstantTemplate(p).resolve_data({}), p)
+
 
 class TestMakoSafetyHardening(TestCase):
     def _assert_forbidden(self, payload):
@@ -430,3 +462,33 @@ class TestMakoSafetyHardening(TestCase):
             self.assertNotIn(name, rb)
         for name in ("len", "str", "range", "int", "__import__"):
             self.assertIn(name, rb)
+
+    def test_dangerous_attr_names_are_blocked_always_on(self):
+        for attr in ("os", "sys", "subprocess", "builtins", "modules", "system", "popen", "kill"):
+            with self.subTest(attr=attr):
+                self._assert_forbidden("${obj.%s}" % attr)
+
+    def test_reserved_namespace_chain_is_blocked_always_on(self):
+        for payload in (
+            '${self.module.cache.util}',
+            "${context.lookup}",
+            "${local.x}",
+            "${parent.foo}",
+            "${caller.body()}",
+            "${pageargs.x}",
+        ):
+            with self.subTest(payload=payload):
+                self._assert_forbidden(payload)
+
+    def test_filter_import_modules_rejects_dangerous_keeps_safe(self):
+        from bamboo_engine.template import sandbox as engine_sandbox
+
+        src = {
+            "os": "os",
+            "subprocess": "subprocess",
+            "operator": "operator",
+            "pickle": "pickle",
+            "os.path": "os.path",
+            "json": "json",
+        }
+        self.assertEqual(set(engine_sandbox.filter_import_modules(src)), {"os.path", "json"})

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -59,10 +59,12 @@ class TestConstantTemplate(TestCase):
 
     def test_resolve_template_with_curly_braces(self):
         cons_tmpl = expression.ConstantTemplate("")
-        one_template = '${"test_{}".format(a)}'
-        self.assertEqual(cons_tmpl.resolve_string(one_template, {"a": "1"}), "test_1")
-        ano_template = '${f"test_{a}"}'
-        self.assertEqual(cons_tmpl.resolve_template(ano_template, {"a": "2"}), "test_2")
+        format_attr_template = '${"test_{}".format(a)}'
+        self.assertEqual(cons_tmpl.resolve_string(format_attr_template, {"a": "1"}), format_attr_template)
+        percent_template = '${"test_%s" % a}'
+        self.assertEqual(cons_tmpl.resolve_string(percent_template, {"a": "1"}), "test_1")
+        fstring_template = '${f"test_{a}"}'
+        self.assertEqual(cons_tmpl.resolve_template(fstring_template, {"a": "2"}), "test_2")
 
     def test_resolve_string(self):
         cons_tmpl = expression.ConstantTemplate("")

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -16,8 +16,10 @@ import datetime
 
 from django.test import TestCase
 
-from pipeline.core.data import expression, sandbox
+from pipeline.core.data import expression, mako_safety, sandbox
 from pipeline.core.data.expression import format_constant_key, deformat_constant_key
+from pipeline.utils.mako_utils.checker import check_mako_template_safety
+from pipeline.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
 class TestConstantTemplate(TestCase):
@@ -214,3 +216,151 @@ class TestConstantTemplate(TestCase):
             self.assertEqual(expression.ConstantTemplate(at).resolve_data({}), at)
 
         sandbox.SANDBOX = sandbox_copy
+
+
+class TestMakoNameWhitelist(TestCase):
+    def setUp(self):
+        from bamboo_engine.config import Settings as BambooSettings
+
+        self._BambooSettings = BambooSettings
+        self._original_mode = BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE
+        self._original_extra = BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
+    def tearDown(self):
+        self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = self._original_mode
+        self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = self._original_extra
+
+    def _set_mode(self, mode, extra=()):
+        self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
+        self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
+
+    def test_off_mode_keeps_legacy_behavior(self):
+        self._set_mode("off")
+        payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertIn("OFF", rendered)
+
+    def test_default_mode_blocks_self_module(self):
+        payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertEqual(rendered, payload)
+
+    def test_enforce_blocks_self_module(self):
+        self._set_mode("enforce")
+        payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+        rendered = expression.ConstantTemplate(payload).resolve_data({})
+        self.assertEqual(rendered, payload)
+
+    def test_dangerous_attr_chain_blocked(self):
+        self._set_mode("enforce")
+        original_imports = self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES
+        self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = {
+            "datetime": "datetime",
+            "re": "re",
+            "os.path": "os.path",
+        }
+        try:
+            payloads = [
+                '${os.path.os.popen("echo PWNED").read()}',
+                '${os.path.genericpath.os.popen("echo PWNED").read()}',
+                '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+                '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+            ]
+            for p in payloads:
+                with self.subTest(payload=p):
+                    rendered = expression.ConstantTemplate(p).resolve_data({})
+                    self.assertEqual(rendered, p)
+        finally:
+            self._BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+    def test_single_underscore_attr_blocked(self):
+        self._set_mode("enforce")
+        for p in [
+            "${context._kwargs}",
+            "${context._with_template}",
+            "${obj._secret}",
+        ]:
+            with self.subTest(payload=p):
+                rendered = expression.ConstantTemplate(p).resolve_data({"obj": object()})
+                self.assertEqual(rendered, p)
+
+    def test_business_patterns_still_render(self):
+        self._set_mode("enforce")
+        cases = [
+            ("${name.upper()}", {"name": "abc"}, "ABC"),
+            ("${[x * 2 for x in items]}", {"items": [1, 2, 3]}, "[2, 4, 6]"),
+            ("${(lambda y: y + 1)(seed)}", {"seed": 4}, "5"),
+            ("${len(items)}", {"items": [1, 2]}, "2"),
+        ]
+        for tpl, ctx, expected in cases:
+            with self.subTest(tpl=tpl):
+                self.assertEqual(expression.ConstantTemplate(tpl).resolve_data(ctx), expected)
+
+    def test_extra_whitelist_names(self):
+        self._set_mode("enforce", extra=("_loop", "_system"))
+        self.assertEqual(expression.ConstantTemplate("${_loop}").resolve_data({"_loop": 3}), 3)
+        self.assertEqual(expression.ConstantTemplate("${_loop + 1}").resolve_data({"_loop": 4}), "5")
+
+    def test_unknown_root_name_blocked(self):
+        self._set_mode("enforce")
+        payload = "${secret_var}"
+        self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+
+
+class TestMakoSafetyHardening(TestCase):
+    def _assert_forbidden(self, payload):
+        with self.assertRaises(ForbiddenMakoTemplateException):
+            check_mako_template_safety(
+                payload,
+                mako_safety.SingleLineNodeVisitor(),
+                mako_safety.SingleLinCodeExtractor(),
+            )
+
+    def _assert_allowed(self, payload):
+        check_mako_template_safety(
+            payload,
+            mako_safety.SingleLineNodeVisitor(),
+            mako_safety.SingleLinCodeExtractor(),
+        )
+
+    def test_filter_callable_with_side_effect_is_blocked(self):
+        self._assert_forbidden("${'x'|((side_effect() or str))}")
+
+    def test_filter_with_dunder_chain_is_blocked(self):
+        self._assert_forbidden("${'x'|().__class__.__bases__[0].__subclasses__}")
+
+    def test_filter_list_with_malicious_item_is_blocked(self):
+        self._assert_forbidden("${'x'|h, (side_effect() or str)}")
+
+    def test_decode_filter_with_dunder_is_blocked(self):
+        self._assert_forbidden("${'x'|decode.__class__}")
+
+    def test_tag_level_expression_filter_is_blocked(self):
+        self._assert_forbidden('<%page expression_filter="(side_effect() or str)"/>${name}')
+
+    def test_tag_level_def_filter_is_blocked(self):
+        payload = '<%def name="r(x)" filter="(side_effect() or str)">${x}</%def>${r("x")}'
+        self._assert_forbidden(payload)
+
+    def test_tag_level_block_filter_is_blocked(self):
+        self._assert_forbidden('<%block filter="(side_effect() or str)">x</%block>')
+
+    def test_tag_level_text_filter_is_blocked(self):
+        self._assert_forbidden('<%text filter="(side_effect() or str)">x</%text>')
+
+    def test_format_attribute_call_is_blocked(self):
+        self._assert_forbidden('${"{0.__class__}".format("")}')
+
+    def test_format_map_attribute_call_is_blocked(self):
+        self._assert_forbidden('${"{value.__class__}".format_map({"value": ""})}')
+
+    def test_builtin_filters_remain_allowed(self):
+        for payload in [
+            "${' x ' | h}",
+            "${' x ' | trim}",
+            "${' x ' | h, trim}",
+            "${'x' | n}",
+            "${b'abc' | decode.utf8}",
+        ]:
+            with self.subTest(payload=payload):
+                self._assert_allowed(payload)

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -335,6 +335,16 @@ class TestMakoNameWhitelist(TestCase):
         payload = "${secret_var}"
         self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
 
+    def test_generator_frame_gadget_blocked_all_modes(self):
+        payload = (
+            "${(i for i in [1]).gi_frame.f_builtins['eval']"
+            "(\"__import__('os').popen('echo PWNED').read()\")}"
+        )
+        for mode in ("off", "warn", "enforce"):
+            with self.subTest(mode=mode):
+                self._set_mode(mode)
+                self.assertEqual(expression.ConstantTemplate(payload).resolve_data({}), payload)
+
 
 class TestMakoSafetyHardening(TestCase):
     def _assert_forbidden(self, payload):
@@ -393,3 +403,30 @@ class TestMakoSafetyHardening(TestCase):
         ]:
             with self.subTest(payload=payload):
                 self._assert_allowed(payload)
+
+    def test_frame_introspection_attrs_are_blocked(self):
+        for attr in [
+            "gi_frame",
+            "gi_code",
+            "cr_frame",
+            "ag_frame",
+            "f_back",
+            "f_builtins",
+            "f_globals",
+            "f_locals",
+            "f_code",
+            "tb_frame",
+            "tb_next",
+            "func_globals",
+        ]:
+            with self.subTest(attr=attr):
+                self._assert_forbidden("${obj.%s}" % attr)
+
+    def test_restricted_builtins_strips_execution_primitives(self):
+        from bamboo_engine.template import sandbox as engine_sandbox
+
+        rb = engine_sandbox.restricted_builtins()
+        for name in ("eval", "exec", "compile", "open", "input", "breakpoint"):
+            self.assertNotIn(name, rb)
+        for name in ("len", "str", "range", "int", "__import__"):
+            self.assertIn(name, rb)

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -492,3 +492,56 @@ class TestMakoSafetyHardening(TestCase):
             "json": "json",
         }
         self.assertEqual(set(engine_sandbox.filter_import_modules(src)), {"os.path", "json"})
+
+
+class TestRenderBackendSeam(TestCase):
+    """校验 ``ConstantTemplate.resolve_template`` 已下沉到可插拔 render backend，且默认行为不变。"""
+
+    def setUp(self):
+        from bamboo_engine.template import render_backend
+
+        render_backend.reset_render_backend()
+
+    def tearDown(self):
+        from bamboo_engine.template import render_backend
+
+        render_backend.reset_render_backend()
+
+    def test_default_backend_preserves_inprocess_render(self):
+        self.assertEqual(expression.ConstantTemplate.resolve_template("${a}", {"a": "1"}), "1")
+        self.assertEqual(expression.ConstantTemplate.resolve_template("${a+int(b)}", {"a": 2, "b": "3"}), "5")
+
+    def test_compile_and_render_errors_stay_inert(self):
+        self.assertEqual(expression.ConstantTemplate.resolve_template("${", {}), "${")
+        self.assertEqual(expression.ConstantTemplate.resolve_template("${nope}", {}), "${nope}")
+
+    def test_resolve_template_rejects_non_string(self):
+        with self.assertRaises(expression.exceptions.ConstantTypeException):
+            expression.ConstantTemplate.resolve_template(123, {})
+
+    def test_resolve_template_routes_through_configured_backend(self):
+        from bamboo_engine.template import render_backend
+
+        calls = []
+
+        class _StubBackend(render_backend.RenderBackend):
+            def render(self, template, context, sandbox_builder):
+                calls.append((template, context, sandbox_builder))
+                return "STUB::" + template
+
+        render_backend.set_render_backend(_StubBackend())
+        out = expression.ConstantTemplate.resolve_template("${a}", {"a": 1})
+        self.assertEqual(out, "STUB::${a}")
+        self.assertEqual(len(calls), 1)
+        template_arg, context_arg, sandbox_builder = calls[0]
+        self.assertEqual(template_arg, "${a}")
+        self.assertEqual(context_arg, {"a": 1})
+        # the seam must pass the sandbox *builder* callable (for subprocess-local rebuild), not a dict
+        self.assertTrue(callable(sandbox_builder))
+        self.assertIsInstance(sandbox_builder(), dict)
+
+    def test_render_sandbox_builder_reads_expression_sandbox_at_call_time(self):
+        # The builder must resolve expression.SANDBOX at call time (matching the historical
+        # ``data.update(SANDBOX)``), so rebinding pipeline.core.data.sandbox.SANDBOX elsewhere
+        # never diverges the render source from what callers mutate via expression.SANDBOX.
+        self.assertIs(expression._mako_render_sandbox(), expression.SANDBOX)

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_expression.py
@@ -236,6 +236,26 @@ class TestMakoNameWhitelist(TestCase):
         self._BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
         self._BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
 
+    def test_existing_format_expressions_only_blocked_in_enforce(self):
+        from types import SimpleNamespace
+
+        cases = [
+            (
+                '${"gamedb.{}.xzj.db".format(set_info.bk_set_name[_loop-1])}',
+                {"set_info": SimpleNamespace(bk_set_name=["zone1"]), "_loop": 1},
+                "gamedb.zone1.xzj.db",
+            ),
+            ('${",".join(["haha{}".format(g) for g in groups])}', {"groups": ["a", "b"]}, "hahaa,hahab"),
+        ]
+        for mode in ("off", "warn", "enforce"):
+            self._set_mode(mode)
+            for template, context, expected in cases:
+                with self.subTest(mode=mode, template=template):
+                    self.assertEqual(
+                        expression.ConstantTemplate(template).resolve_data(context),
+                        template if mode == "enforce" else expected,
+                    )
+
     def test_off_mode_also_blocks_self_module(self):
         # 保留命名空间属性链下沉 always-on 后，off 模式也 inert
         # （此前 off 会解析出真实 os 模块执行命令，这里回归为拦截）。
@@ -419,8 +439,13 @@ class TestMakoSafetyHardening(TestCase):
     def test_tag_level_text_filter_is_blocked(self):
         self._assert_forbidden('<%text filter="(side_effect() or str)">x</%text>')
 
-    def test_format_attribute_call_is_blocked(self):
-        self._assert_forbidden('${"{0.__class__}".format("")}')
+    def test_format_attribute_call_is_blocked_in_enforce(self):
+        with self.assertRaises(ForbiddenMakoTemplateException):
+            check_mako_template_safety(
+                '${"{0.__class__}".format("")}',
+                mako_safety.WhitelistNameVisitor(set(), mode="enforce"),
+                mako_safety.SingleLinCodeExtractor(),
+            )
 
     def test_format_map_attribute_call_is_blocked(self):
         self._assert_forbidden('${"{value.__class__}".format_map({"value": ""})}')

--- a/runtime/bamboo-pipeline/pipeline/tests/core/data/test_sandbox_builder.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/core/data/test_sandbox_builder.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+# NOTE: this module is intentionally Django-free and MUST be importable/usable without configuring
+# Django settings, so that an isolated (spawn) render worker can rebuild the legacy sandbox without
+# pulling the app + its credentials back into the worker process.
+
+from pipeline.core.data import sandbox_builder
+
+
+def test_build_sandbox_includes_mock_builtins():
+    sb = sandbox_builder.build_sandbox([], {})
+    # mock builtins render as their name and are callable proxies to the real builtin
+    assert str(sb["int"]) == "int"
+    assert sb["int"]("3") == 3
+    assert str(sb["len"]) == "len"
+    assert sb["len"]([1, 2, 3]) == 3
+
+
+def test_build_sandbox_applies_shield_words():
+    sb = sandbox_builder.build_sandbox(["exec", "compile"], {})
+    assert sb["exec"] is None
+    assert sb["compile"] is None
+
+
+def test_build_sandbox_imports_modules():
+    sb = sandbox_builder.build_sandbox([], {"datetime": "datetime"})
+    assert type(sb["datetime"]).__name__ == "module"
+
+
+def test_build_sandbox_imports_dotted_alias_as_module_object():
+    sb = sandbox_builder.build_sandbox([], {"datetime.datetime": "datetime.datetime"})
+    # dotted alias becomes a ModuleObject chain: sb["datetime"].datetime is the class
+    assert isinstance(sb["datetime"], sandbox_builder.ModuleObject)
+    assert sb["datetime"].datetime.__name__ == "datetime"
+
+
+def test_build_sandbox_rejects_dangerous_import_modules():
+    sb = sandbox_builder.build_sandbox([], {"os": "os", "subprocess": "subprocess", "json": "json"})
+    assert "os" not in sb
+    assert "subprocess" not in sb
+    assert type(sb["json"]).__name__ == "module"
+
+
+def test_build_sandbox_returns_fresh_dict_each_call():
+    a = sandbox_builder.build_sandbox([], {})
+    b = sandbox_builder.build_sandbox([], {})
+    assert a is not b
+    assert a["int"] is not None and b["int"] is not None

--- a/runtime/bamboo-pipeline/pipeline/utils/mako_utils/checker.py
+++ b/runtime/bamboo-pipeline/pipeline/utils/mako_utils/checker.py
@@ -19,8 +19,19 @@ from mako import parsetree
 from mako.exceptions import MakoException
 from mako.lexer import Lexer
 
+from pipeline.core.data import mako_safety
+
 from .code_extract import MakoNodeCodeExtractor
 from .exceptions import ForbiddenMakoTemplateException
+
+
+def validate_node_filter_callables(node: parsetree.Node):
+    # Mako stores inline `${expr | ...}` filter callables in `escapes_code`;
+    # tag-level filters use `filter_args`. Both are executed by create_filter_callable().
+    if hasattr(node, "escapes_code"):
+        mako_safety.validate_filter_args(node.escapes_code.args)
+    if hasattr(node, "filter_args"):
+        mako_safety.validate_filter_args(node.filter_args.args)
 
 
 def parse_template_nodes(
@@ -33,14 +44,15 @@ def parse_template_nodes(
     :param code_extractor: Mako 词法节点处理器，用于提取 python 代码
     """
     for node in nodes:
-        code = code_extractor.extract(node)
-        if code is None:
-            continue
+        validate_node_filter_callables(node)
 
-        ast_node = ast.parse(code, "<unknown>", "exec")
-        node_visitor.visit(ast_node)
+        code = code_extractor.extract(node)
+        if code is not None:
+            ast_node = ast.parse(code, "<unknown>", "exec")
+            node_visitor.visit(ast_node)
+
         if hasattr(node, "nodes"):
-            parse_template_nodes(node.nodes, node_visitor)
+            parse_template_nodes(node.nodes, node_visitor, code_extractor)
 
 
 def check_mako_template_safety(text: str, node_visitor: ast.NodeVisitor, code_extractor: MakoNodeCodeExtractor) -> bool:

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "3.24.16"
+version = "3.24.17"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"
@@ -16,7 +16,7 @@ requests = "^2.22"
 django-celery-beat = "^2.1"
 Mako = "^1.1.4"
 pytz = ">=2019.3"
-bamboo-engine = "2.6.5"
+bamboo-engine = "2.6.6"
 jsonschema = "^2.5.1"
 ujson = "^4"
 pyparsing = "^2.2"

--- a/tests/template/test_format_mode.py
+++ b/tests/template/test_format_mode.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from bamboo_engine.config import Settings
+from bamboo_engine.template import Template
+from bamboo_engine.utils import mako_safety
+from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
+from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
+
+
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+def test_format_renders_only_outside_enforce(monkeypatch, mode):
+    monkeypatch.setattr(Settings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", mode)
+    template = "${pattern.format(name)}"
+    assert Template(template).render({"pattern": "gamedb.{}.xzj.db", "name": "zone1"}) == (
+        template if mode == "enforce" else "gamedb.zone1.xzj.db"
+    )
+
+
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+def test_format_map_and_custom_filters_stay_blocked(monkeypatch, mode):
+    monkeypatch.setattr(Settings, "MAKO_TEMPLATE_NAME_WHITELIST_MODE", mode)
+    for template in ("${pattern.format_map(values)}", "${name | custom}"):
+        assert (
+            Template(template).render({"pattern": "{name}", "values": {"name": "prod"}, "name": "prod", "custom": str})
+            == template
+        )
+
+
+@pytest.mark.parametrize("payload", ['${"{0.__class__}".format("")}', "${pattern.format}"])
+def test_enforce_blocks_format_lookup_and_method_reference(payload):
+    with pytest.raises(ForbiddenMakoTemplateException):
+        check_mako_template_safety(
+            payload,
+            mako_safety.WhitelistNameVisitor({"pattern"}, mode="enforce"),
+            mako_safety.SingleLinCodeExtractor(),
+        )

--- a/tests/template/test_mako_attr_policy.py
+++ b/tests/template/test_mako_attr_policy.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import ast
+
+from bamboo_engine.utils.mako_safety import import_chain_violation, resolve_attr_chain
+
+
+def _attr_node(expr):
+    tree = ast.parse(expr, "<t>", "eval")
+    node = tree.body
+    while isinstance(node, ast.Call):
+        node = node.func
+    assert isinstance(node, ast.Attribute)
+    return node
+
+
+def test_resolve_attr_chain_name_two_levels():
+    kind, root, attrs = resolve_attr_chain(_attr_node("json.codecs.builtins"))
+    assert kind == "name"
+    assert root == "json"
+    assert attrs == ["codecs", "builtins"]
+
+
+def test_resolve_attr_chain_stops_at_call():
+    kind, root, attrs = resolve_attr_chain(_attr_node('datetime.datetime.now().strftime("%Y")'))
+    assert kind == "call_result"
+    assert root is None
+    assert attrs == ["strftime"]
+
+
+def test_import_json_loads_ok():
+    aliases = frozenset(["json", "re", "os.path", "datetime", "datetime.datetime"])
+    assert import_chain_violation("json", ["loads"], aliases) is None
+
+
+def test_import_os_path_join_ok():
+    aliases = frozenset(["os.path", "json"])
+    assert import_chain_violation("os", ["path", "join"], aliases) is None
+
+
+def test_import_os_popen_rejected():
+    aliases = frozenset(["os.path"])
+    reason = import_chain_violation("os", ["popen"], aliases)
+    assert reason is not None
+
+
+def test_import_json_codecs_builtins_rejected():
+    aliases = frozenset(["json"])
+    reason = import_chain_violation("json", ["codecs", "builtins"], aliases)
+    assert reason is not None
+
+
+def test_import_datetime_now_needs_class_alias():
+    aliases = frozenset(["datetime"])
+    assert import_chain_violation("datetime", ["datetime", "now"], aliases) is not None
+    aliases = frozenset(["datetime", "datetime.datetime"])
+    assert import_chain_violation("datetime", ["datetime", "now"], aliases) is None
+
+
+def test_non_import_root_is_ignored():
+    aliases = frozenset(["json"])
+    assert import_chain_violation("resdata", ["_module"], aliases) is None

--- a/tests/template/test_render_backend.py
+++ b/tests/template/test_render_backend.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+
+from bamboo_engine.template.render_backend import (
+    InProcessRenderBackend,
+    RenderBackend,
+    get_render_backend,
+    reset_render_backend,
+    set_render_backend,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend():
+    reset_render_backend()
+    yield
+    reset_render_backend()
+
+
+def _empty_sandbox():
+    return {}
+
+
+def test_inprocess_backend_renders_template_with_context():
+    result = InProcessRenderBackend().render("${a} and ${b}", {"a": "x", "b": "y"}, _empty_sandbox)
+    assert result == "x and y"
+
+
+def test_inprocess_backend_merges_sandbox_builder_into_namespace():
+    def sandbox():
+        return {"greet": lambda who: "hi " + who}
+
+    result = InProcessRenderBackend().render("${greet(name)}", {"name": "bob"}, sandbox)
+    assert result == "hi bob"
+
+
+def test_context_overrides_sandbox_on_key_collision():
+    def sandbox():
+        return {"a": "from_sandbox"}
+
+    result = InProcessRenderBackend().render("${a}", {"a": "from_context"}, sandbox)
+    assert result == "from_context"
+
+
+def test_inprocess_backend_returns_template_inert_on_compile_error():
+    tpl = "${"  # unbalanced expression -> compile failure
+    assert InProcessRenderBackend().render(tpl, {}, _empty_sandbox) == tpl
+
+
+def test_inprocess_backend_returns_template_inert_on_render_error():
+    tpl = "${undefined_name_xyz}"  # NameError at render time
+    assert InProcessRenderBackend().render(tpl, {}, _empty_sandbox) == tpl
+
+
+def test_inprocess_backend_applies_shield_word_from_sandbox():
+    # The real production defense for bare ``${eval(...)}`` is the sandbox shield word
+    # (``eval`` bound to None in the namespace), which turns the call into a TypeError
+    # and renders inert. This asserts the backend feeds shield words into the namespace.
+    def sandbox():
+        return {"eval": None}
+
+    tpl = "${eval('1+1')}"
+    assert InProcessRenderBackend().render(tpl, {}, sandbox) == tpl
+
+
+def test_inprocess_backend_invokes_harden_before_render(monkeypatch):
+    # Behavior-preservation guarantee: the refactor must still call harden_template_builtins
+    # on the compiled template before executing it (defense-in-depth layer stays wired).
+    calls = []
+    import bamboo_engine.template.render_backend as rb
+
+    def _spy(mako_template):
+        calls.append(mako_template)
+
+    monkeypatch.setattr(rb, "harden_template_builtins", _spy)
+    result = InProcessRenderBackend().render("${a}", {"a": "ok"}, _empty_sandbox)
+    assert result == "ok"
+    assert len(calls) == 1
+
+
+def test_get_render_backend_defaults_to_inprocess():
+    backend = get_render_backend()
+    assert isinstance(backend, RenderBackend)
+    assert isinstance(backend, InProcessRenderBackend)
+
+
+def test_get_render_backend_is_cached_singleton():
+    assert get_render_backend() is get_render_backend()
+
+
+def test_set_render_backend_overrides_default():
+    sentinel = InProcessRenderBackend()
+    set_render_backend(sentinel)
+    assert get_render_backend() is sentinel
+
+
+def test_reset_render_backend_rebuilds_default():
+    sentinel = InProcessRenderBackend()
+    set_render_backend(sentinel)
+    reset_render_backend()
+    assert get_render_backend() is not sentinel

--- a/tests/template/test_render_backend_failures.py
+++ b/tests/template/test_render_backend_failures.py
@@ -1,0 +1,387 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for the isolation boundary and bounded pool lifecycle."""
+import multiprocessing
+import os
+import pickle
+import subprocess
+import threading
+import time
+from collections import Counter, namedtuple
+
+import pytest
+
+from bamboo_engine.template import render_backend as rb
+from bamboo_engine.template import sandbox
+
+
+def provider():
+    return rb.SandboxProvider(sandbox.get, rb.SandboxSpec("engine", [], {}))
+
+
+def pool(**kwargs):
+    opts = dict(pool_size=1, timeout=3, os_harden=False, no_network=False)
+    opts.update(kwargs)
+    return rb.SubprocessPoolRenderBackend(**opts)
+
+
+_REPLY_EXECUTED = []
+
+
+def mark_reply_execution():
+    _REPLY_EXECUTED.append(True)
+    return "executed"
+
+
+class ExecutableReply:
+    def __reduce__(self):
+        return mark_reply_execution, ()
+
+
+class ReplyConnection:
+    def send_bytes(self, *args, **kwargs):
+        pass
+
+    def poll(self, *args):
+        return True
+
+    def recv_bytes(self, *args, **kwargs):
+        return pickle.dumps((0, ExecutableReply()))
+
+
+def test_worker_reply_cannot_execute_in_parent():
+    worker = object.__new__(rb._RenderWorker)
+    worker._conn = ReplyConnection()
+    worker.uses = 0
+    _REPLY_EXECUTED[:] = []
+    try:
+        worker.request(b"request", 1)
+    except (ValueError, UnicodeError):
+        pass
+    assert _REPLY_EXECUTED == []
+
+
+def _daemon_render(out):
+    backend = pool()
+    try:
+        out.put(backend.render("${x+1}", {"x": 2}, provider()))
+    except Exception as exc:
+        out.put(type(exc).__name__)
+    finally:
+        backend.close()
+
+
+def test_real_daemon_host_can_render():
+    ctx = multiprocessing.get_context("spawn")
+    out = ctx.Queue()
+    process = ctx.Process(target=_daemon_render, args=(out,), daemon=True)
+    process.start()
+    try:
+        assert out.get(timeout=8) == "3"
+    finally:
+        process.join(3)
+        if process.is_alive():
+            process.terminate()
+            process.join(2)
+        out.close()
+
+
+Record = namedtuple("Record", "name")
+
+
+class WithProperty:
+    def __init__(self):
+        self.value = 7
+
+    @property
+    def double(self):
+        return self.value * 2
+
+
+@pytest.mark.parametrize(
+    "template,value,expected",
+    [
+        ("${v.tm_year}", time.gmtime(0), "1970"),
+        ("${v.most_common(1)}", Counter("aab"), "[('a', 2)]"),
+        ("${v.name}", Record("prod"), "prod"),
+        ("${v.double}", WithProperty(), "14"),
+    ],
+)
+def test_rich_context_never_silently_loses_behavior(template, value, expected):
+    backend = pool(fallback_inprocess=True)
+    try:
+        assert backend.render(template, {"v": value}, provider()) == expected
+    finally:
+        backend.close()
+
+
+def test_recycle_does_not_mask_success_and_spawn_failure_can_recover(monkeypatch):
+    backend = pool(max_uses=1)
+    spawn = backend._spawn_worker
+    calls = []
+
+    def fail_second_spawn():
+        calls.append(1)
+        if len(calls) == 2:
+            raise OSError(11, "synthetic process quota")
+        return spawn()
+
+    monkeypatch.setattr(backend, "_spawn_worker", fail_second_spawn)
+    try:
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "3"
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "${x+1}"
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "3"
+    finally:
+        backend.close()
+
+
+def test_startup_and_admission_share_deadline(monkeypatch):
+    backend = pool(timeout=0.1)
+    entered = threading.Event()
+    release = threading.Event()
+    spawn = backend._spawn_worker
+
+    def stalled_spawn():
+        entered.set()
+        release.wait(1)
+        return spawn()
+
+    monkeypatch.setattr(backend, "_spawn_worker", stalled_spawn)
+    try:
+        start = time.monotonic()
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "${x+1}"
+        assert time.monotonic() - start < 0.5
+        assert entered.is_set()
+        start = time.monotonic()
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "${x+1}"
+        assert time.monotonic() - start < 0.5
+    finally:
+        release.set()
+        backend.close()
+
+
+def test_missing_spec_honors_strict_policy():
+    backend = pool()
+    try:
+        assert backend.render("${x+1}", {"x": 2}, sandbox.get) == "${x+1}"
+    finally:
+        backend.close()
+
+
+def test_worker_error_cannot_force_opted_in_fallback(monkeypatch):
+    backend = pool(fallback_inprocess=True)
+
+    def broken_reply(*args, **kwargs):
+        raise rb.ProtocolError("synthetic invalid worker reply")
+
+    monkeypatch.setattr(rb._RenderWorker, "request", broken_reply)
+    try:
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "${x+1}"
+    finally:
+        backend.close()
+
+
+def test_no_network_requirement_fails_closed(monkeypatch):
+    monkeypatch.setattr(rb.sys, "platform", "darwin")
+    with pytest.raises(RuntimeError):
+        rb._apply_os_hardening({"enabled": True, "no_network": True})
+
+
+def test_late_cancel_does_not_kill_worker_reused_by_next_job(monkeypatch):
+    backend = pool()
+    jobs = []
+    run = backend._run
+
+    def capture(job, *args):
+        jobs.append(job)
+        return run(job, *args)
+
+    monkeypatch.setattr(backend, "_run", capture)
+    try:
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "3"
+        request = rb._RenderWorker.request
+
+        def cancel_previous(worker, *args):
+            jobs[0].cancel()
+            return request(worker, *args)
+
+        monkeypatch.setattr(rb._RenderWorker, "request", cancel_previous)
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "3"
+    finally:
+        backend.close()
+
+
+def test_close_wakes_callers_waiting_for_a_slot(monkeypatch):
+    backend = pool(timeout=5)
+    entered = threading.Event()
+    release = threading.Event()
+    results = []
+
+    def stalled_spawn():
+        entered.set()
+        release.wait(2)
+        raise OSError("cancelled synthetic launch")
+
+    monkeypatch.setattr(backend, "_spawn_worker", stalled_spawn)
+    callers = [
+        threading.Thread(target=lambda: results.append(backend.render("${x+1}", {"x": 2}, provider())))
+        for _ in range(2)
+    ]
+    try:
+        callers[0].start()
+        assert entered.wait(1)
+        callers[1].start()
+        backend.close()
+        for caller in callers:
+            caller.join(0.5)
+            assert not caller.is_alive()
+        assert results == ["${x+1}", "${x+1}"]
+    finally:
+        release.set()
+        backend.close()
+
+
+def test_unsupported_property_is_rejected_before_lossy_conversion():
+    with pytest.raises(rb.UnsupportedContext):
+        rb._portable_context({"v": WithProperty()})
+
+
+def test_cycles_and_excessive_object_counts_are_rejected(monkeypatch):
+    cyclic = []
+    cyclic.append(cyclic)
+    with pytest.raises(rb.UnsupportedContext):
+        rb._portable_context({"v": cyclic})
+    monkeypatch.setattr(rb, "_PORTABLE_MAX_ITEMS", 10)
+    with pytest.raises(rb.UnsupportedContext):
+        rb._portable_context({"v": list(range(100))})
+
+
+def test_pool_concurrent_requests_return_their_own_results():
+    from concurrent.futures import ThreadPoolExecutor
+
+    backend = pool(pool_size=2, max_uses=3, timeout=5)
+    try:
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(lambda n: backend.render("${x+1}", {"x": n}, provider()), range(24)))
+        assert results == [str(n) for n in range(1, 25)]
+    finally:
+        backend.close()
+
+
+def test_unreaped_worker_keeps_its_slot(monkeypatch):
+    backend = pool(timeout=0.2, max_uses=1)
+    entered = threading.Event()
+    release = threading.Event()
+    stop = rb._RenderWorker.stop
+
+    def delayed_reap(worker):
+        if not release.is_set():
+            entered.set()
+            worker.kill()
+            return False
+        return stop(worker)
+
+    monkeypatch.setattr(rb._RenderWorker, "stop", delayed_reap)
+    try:
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "3"
+        assert entered.wait(1)
+        assert backend.render("${x+1}", {"x": 2}, provider()) == "${x+1}"
+    finally:
+        release.set()
+        backend.close()
+
+
+def test_close_handles_dequeued_but_not_registered_slot(monkeypatch):
+    backend = pool()
+    assert backend.render("${x+1}", {"x": 2}, provider()) == "3"
+    entered = threading.Event()
+    release = threading.Event()
+    get = backend._idle.get
+
+    def delayed_get(*args, **kwargs):
+        slot = get(*args, **kwargs)
+        if kwargs.get("block") is not False:
+            entered.set()
+            release.wait(1)
+        return slot
+
+    monkeypatch.setattr(backend._idle, "get", delayed_get)
+    caller = threading.Thread(target=lambda: backend.render("${x+1}", {"x": 2}, provider()))
+    try:
+        caller.start()
+        assert entered.wait(1)
+        backend.close()
+        release.set()
+        caller.join(1)
+        for slot in backend._slots:
+            if slot.thread is not None:
+                slot.thread.join(1)
+                assert not slot.thread.is_alive()
+    finally:
+        release.set()
+        backend.close()
+
+
+def test_caller_interruption_cancels_its_job(monkeypatch):
+    backend = pool()
+    jobs = []
+    init = rb._RenderJob.__init__
+
+    def interrupt_init(job, *args):
+        init(job, *args)
+        jobs.append(job)
+
+        def interrupted(*args):
+            raise KeyboardInterrupt()
+
+        job.done.wait = interrupted
+
+    monkeypatch.setattr(rb._RenderJob, "__init__", interrupt_init)
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            backend.render("${x+1}", {"x": 2}, provider())
+        assert jobs[0].cancelled.is_set()
+    finally:
+        backend.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX fork lifecycle")
+def test_fork_closes_transports_of_worker_still_starting(monkeypatch):
+    backend = pool(timeout=2)
+    entered = threading.Event()
+    release = threading.Event()
+    popen = subprocess.Popen
+
+    def stalled_popen(*args, **kwargs):
+        entered.set()
+        release.wait(2)
+        return popen(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", stalled_popen)
+    results = []
+    caller = threading.Thread(target=lambda: results.append(backend.render("${x+1}", {"x": 2}, provider())))
+    try:
+        caller.start()
+        assert entered.wait(1)
+        fds = [sock.fileno() for sock in rb._WORKER_SOCKETS]
+        assert len(fds) >= 2
+        child = os.fork()
+        if child == 0:
+            try:
+                backend._ensure_process()
+                for fd in fds:
+                    try:
+                        os.fstat(fd)
+                    except OSError:
+                        continue
+                    os._exit(2)
+                os._exit(0)
+            except BaseException:
+                os._exit(3)
+        _, status = os.waitpid(child, 0)
+        assert status == 0
+        release.set()
+        caller.join(3)
+        assert results == ["3"]  # closing child copies did not damage parent transport
+    finally:
+        release.set()
+        backend.close()

--- a/tests/template/test_render_backend_seam.py
+++ b/tests/template/test_render_backend_seam.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+
+from bamboo_engine.template.template import Template
+from bamboo_engine.template.render_backend import (
+    RenderBackend,
+    reset_render_backend,
+    set_render_backend,
+)
+
+
+class _StubBackend(RenderBackend):
+    def __init__(self):
+        self.calls = []
+
+    def render(self, template, context, sandbox_builder):
+        self.calls.append((template, context, sandbox_builder))
+        return "STUB::" + template
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend():
+    reset_render_backend()
+    yield
+    reset_render_backend()
+
+
+def test_engine_render_template_routes_through_configured_backend():
+    stub = _StubBackend()
+    set_render_backend(stub)
+    out = Template._render_template("${a}", {"a": 1})
+    assert out == "STUB::${a}"
+    assert len(stub.calls) == 1
+    template_arg, context_arg, sandbox_builder = stub.calls[0]
+    assert template_arg == "${a}"
+    assert context_arg == {"a": 1}
+    # the seam must hand the sandbox *builder* (callable) to the backend, not a pre-built dict,
+    # so an isolated backend can rebuild the sandbox locally in a subprocess.
+    assert callable(sandbox_builder)
+    assert isinstance(sandbox_builder(), dict)
+
+
+def test_engine_render_template_default_backend_still_renders_inprocess():
+    # With no backend override, behavior is unchanged: real in-process render.
+    assert Template._render_template("${a + b}", {"a": 2, "b": 3}) == "5"
+
+
+def test_engine_render_template_rejects_non_string_template():
+    with pytest.raises(TypeError):
+        Template._render_template(123, {})

--- a/tests/template/test_render_os_hardening.py
+++ b/tests/template/test_render_os_hardening.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import sys
+
+import pytest
+
+from bamboo_engine.template import render_backend as rb
+
+
+def test_apply_os_hardening_noop_when_opts_none():
+    # 无配置 → 直接 no-op，不得抛出。
+    assert rb._apply_os_hardening(None) is None
+
+
+def test_apply_os_hardening_noop_when_disabled():
+    assert rb._apply_os_hardening({"enabled": False, "no_network": True, "rlimit_cpu": 1}) is None
+
+
+@pytest.mark.skipif(sys.platform.startswith("linux"), reason="non-Linux no-op path")
+def test_apply_os_hardening_noop_on_non_linux():
+    # macOS/其它平台：即便 enabled，也应 no-op 且不抛出（加固仅 Linux 生效）。
+    assert rb._apply_os_hardening({"enabled": True, "no_network": True, "rlimit_cpu": 1, "rlimit_as_mb": 512}) is None
+
+
+def test_os_hardening_test_hook_takes_precedence():
+    # 注入测试 hook 时优先执行，用于本地/单测覆盖真实加固逻辑。
+    called = []
+    rb._OS_HARDENING_HOOK = lambda: called.append(True)
+    try:
+        rb._apply_os_hardening({"enabled": False})  # 即便 disabled，hook 覆盖仍执行
+        assert called == [True]
+    finally:
+        rb._OS_HARDENING_HOOK = None
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux-only rlimit assertion")
+def test_apply_os_hardening_sets_core_rlimit_zero_on_linux():
+    import resource
+
+    orig = resource.getrlimit(resource.RLIMIT_CORE)
+    try:
+        rb._apply_os_hardening({"enabled": True, "no_network": False, "rlimit_cpu": None, "rlimit_as_mb": None})
+        soft, _ = resource.getrlimit(resource.RLIMIT_CORE)
+        assert soft == 0  # 禁 core dump，避免凭证随 core 落盘
+    finally:
+        try:
+            resource.setrlimit(resource.RLIMIT_CORE, orig)
+        except Exception:
+            pass
+
+
+def test_backend_with_os_harden_enabled_still_renders():
+    # 打开 os_harden 的池在本机（macOS no-op / Linux 加固）都应正常渲染，验证 harden_opts 透传不破渲染。
+    from bamboo_engine.template.render_backend import SandboxProvider, SandboxSpec
+    from bamboo_engine.template import sandbox as engine_sandbox
+
+    provider = SandboxProvider(engine_sandbox.get, SandboxSpec("engine", [], {}))
+    backend = rb.SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0, os_harden=True)
+    try:
+        assert backend.render("${a + b}", {"a": 20, "b": 22}, provider) == "42"
+    finally:
+        backend.close()

--- a/tests/template/test_render_os_hardening.py
+++ b/tests/template/test_render_os_hardening.py
@@ -24,40 +24,36 @@ def test_apply_os_hardening_noop_when_opts_none():
 
 
 def test_apply_os_hardening_noop_when_disabled():
-    assert rb._apply_os_hardening({"enabled": False, "no_network": True, "rlimit_cpu": 1}) is None
+    assert rb._apply_os_hardening({"enabled": False, "no_network": False, "rlimit_cpu": 1}) is None
 
 
-@pytest.mark.skipif(sys.platform.startswith("linux"), reason="non-Linux no-op path")
-def test_apply_os_hardening_noop_on_non_linux():
-    # macOS/其它平台：即便 enabled，也应 no-op 且不抛出（加固仅 Linux 生效）。
-    assert rb._apply_os_hardening({"enabled": True, "no_network": True, "rlimit_cpu": 1, "rlimit_as_mb": 512}) is None
+@pytest.mark.skipif(sys.platform.startswith("linux"), reason="non-Linux isolation failure")
+def test_network_requirement_is_not_ignored_on_non_linux():
+    with pytest.raises(RuntimeError):
+        rb._apply_os_hardening({"enabled": True, "no_network": True})
 
 
-def test_os_hardening_test_hook_takes_precedence():
-    # 注入测试 hook 时优先执行，用于本地/单测覆盖真实加固逻辑。
-    called = []
-    rb._OS_HARDENING_HOOK = lambda: called.append(True)
-    try:
-        rb._apply_os_hardening({"enabled": False})  # 即便 disabled，hook 覆盖仍执行
-        assert called == [True]
-    finally:
-        rb._OS_HARDENING_HOOK = None
+def test_network_unshare_failure_is_not_ignored(monkeypatch):
+    def denied():
+        raise RuntimeError("synthetic EPERM")
+
+    monkeypatch.setattr(rb, "_try_unshare_network", denied)
+    with pytest.raises(RuntimeError):
+        rb._apply_os_hardening({"enabled": False, "no_network": True})
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux-only rlimit assertion")
 def test_apply_os_hardening_sets_core_rlimit_zero_on_linux():
-    import resource
+    import subprocess
 
-    orig = resource.getrlimit(resource.RLIMIT_CORE)
-    try:
-        rb._apply_os_hardening({"enabled": True, "no_network": False, "rlimit_cpu": None, "rlimit_as_mb": None})
-        soft, _ = resource.getrlimit(resource.RLIMIT_CORE)
-        assert soft == 0  # 禁 core dump，避免凭证随 core 落盘
-    finally:
-        try:
-            resource.setrlimit(resource.RLIMIT_CORE, orig)
-        except Exception:
-            pass
+    # Lower hard limits in a disposable process, not the pytest runner.
+    code = (
+        "import resource; "
+        "from bamboo_engine.template.render_backend import _apply_os_hardening; "
+        "_apply_os_hardening(dict(enabled=True,no_network=False)); "
+        "print(resource.getrlimit(resource.RLIMIT_CORE))"
+    )
+    assert subprocess.check_output([sys.executable, "-c", code], timeout=5).strip() == b"(0, 0)"
 
 
 def test_backend_with_os_harden_enabled_still_renders():
@@ -66,7 +62,7 @@ def test_backend_with_os_harden_enabled_still_renders():
     from bamboo_engine.template import sandbox as engine_sandbox
 
     provider = SandboxProvider(engine_sandbox.get, SandboxSpec("engine", [], {}))
-    backend = rb.SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0, os_harden=True)
+    backend = rb.SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0, os_harden=True, no_network=False)
     try:
         assert backend.render("${a + b}", {"a": 20, "b": 22}, provider) == "42"
     finally:

--- a/tests/template/test_render_transport.py
+++ b/tests/template/test_render_transport.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+import socket
+import struct
+import threading
+import time
+
+import pytest
+
+from bamboo_engine.template.render_transport import (
+    SocketConnection,
+    RenderTimeout,
+    ProtocolError,
+    decode_reply,
+    encode_reply,
+)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b'[true,"x"]',
+        b'[2,"x"]',
+        b"[0,{}]",
+        b"[0,1]",
+        b'[0,"x","extra"]',
+        b"null",
+        b"[0,NaN]",
+        b"[0,1e9]",
+        b"[0," + b"9" * 100000 + b"]",
+        b"[" * 2000,
+        b"\xff",
+    ],
+)
+def test_invalid_reply_is_rejected(data):
+    with pytest.raises(ProtocolError):
+        decode_reply(data)
+
+
+def test_text_reply_roundtrip():
+    assert decode_reply(encode_reply(0, '中文\n"\\')) == [0, '中文\n"\\']
+
+
+def test_reply_from_another_request_is_rejected():
+    with pytest.raises(ProtocolError):
+        decode_reply(encode_reply(0, "old result", "a" * 32), "b" * 32)
+
+
+def test_partial_reply_does_not_escape_deadline():
+    parent, child = socket.socketpair()
+    conn = SocketConnection(parent)
+    try:
+        child.sendall(struct.pack("!I", 200) + b"[")
+        start = time.monotonic()
+        with pytest.raises(RenderTimeout):
+            conn.recv_bytes(deadline=start + 0.05)
+        assert time.monotonic() - start < 0.5
+    finally:
+        conn.close()
+        child.close()
+
+
+def test_slow_trickle_cannot_extend_deadline():
+    parent, child = socket.socketpair()
+    conn = SocketConnection(parent)
+    child.sendall(struct.pack("!I", 200))
+
+    def trickle():
+        try:
+            for _ in range(20):
+                child.sendall(b"x")
+                time.sleep(0.02)
+        except OSError:
+            pass
+
+    thread = threading.Thread(target=trickle)
+    thread.start()
+    try:
+        start = time.monotonic()
+        with pytest.raises(RenderTimeout):
+            conn.recv_bytes(deadline=start + 0.08)
+        assert time.monotonic() - start < 0.5
+    finally:
+        conn.close()
+        thread.join(1)
+        child.close()
+
+
+def test_nonreading_worker_cannot_block_large_request():
+    parent, child = socket.socketpair()
+    parent.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+    conn = SocketConnection(parent)
+    try:
+        start = time.monotonic()
+        with pytest.raises(RenderTimeout):
+            conn.send_bytes(b"x" * (2 * 1024 * 1024), deadline=start + 0.05)
+        assert time.monotonic() - start < 0.5
+    finally:
+        conn.close()
+        child.close()
+
+
+def test_oversized_frame_rejected_before_body_read():
+    parent, child = socket.socketpair()
+    conn = SocketConnection(parent)
+    try:
+        child.sendall(struct.pack("!I", 0xFFFFFFFF))
+        with pytest.raises(ProtocolError):
+            conn.recv_bytes(deadline=time.monotonic() + 0.1)
+    finally:
+        conn.close()
+        child.close()

--- a/tests/template/test_sandbox_import.py
+++ b/tests/template/test_sandbox_import.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import datetime as dt
+
+from bamboo_engine.template.sandbox import ModuleObject, _import_modules, resolve_import_object
+
+
+def test_resolve_import_object_module():
+    import json
+
+    assert resolve_import_object("json") is json
+
+
+def test_resolve_import_object_class_path():
+    assert resolve_import_object("datetime.datetime") is dt.datetime
+
+
+def test_dotted_alias_does_not_clobber_existing_module():
+    sandbox = {}
+    _import_modules(
+        sandbox,
+        {
+            "datetime": "datetime",
+            "datetime.datetime": "datetime.datetime",
+        },
+    )
+    assert sandbox["datetime"] is dt
+    assert sandbox["datetime"].datetime is dt.datetime
+    assert sandbox["datetime"].timedelta is dt.timedelta
+    assert not isinstance(sandbox["datetime"], ModuleObject)
+
+
+def test_os_path_still_uses_module_object():
+    sandbox = {}
+    _import_modules(sandbox, {"os.path": "os.path"})
+    assert isinstance(sandbox["os"], ModuleObject)
+    assert hasattr(sandbox["os"], "path")
+    assert not hasattr(sandbox["os"], "popen")

--- a/tests/template/test_sandbox_spec.py
+++ b/tests/template/test_sandbox_spec.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pickle
+
+from bamboo_engine.template import sandbox
+from bamboo_engine.template.render_backend import SandboxProvider, SandboxSpec
+
+
+def test_engine_build_sandbox_applies_shield_and_imports_without_mock_builtins():
+    sb = sandbox.build_sandbox(["exec", "compile"], {"datetime": "datetime"})
+    assert sb["exec"] is None
+    assert sb["compile"] is None
+    assert type(sb["datetime"]).__name__ == "module"
+    # engine flavor has no legacy mock builtins
+    assert "int" not in sb
+
+
+def test_engine_spec_build_matches_engine_build_sandbox():
+    spec = SandboxSpec("engine", ["exec"], {"datetime": "datetime"})
+    d = spec.build()
+    assert d["exec"] is None
+    assert type(d["datetime"]).__name__ == "module"
+    assert "int" not in d
+
+
+def test_sandbox_spec_is_picklable_and_roundtrips():
+    spec = SandboxSpec("legacy", ["exec", "compile"], {"datetime": "datetime"})
+    restored = pickle.loads(pickle.dumps(spec))
+    assert restored.flavor == "legacy"
+    assert restored.shield_words == ["exec", "compile"]
+    assert restored.import_modules == {"datetime": "datetime"}
+
+
+def test_sandbox_provider_is_callable_build_and_exposes_spec():
+    marker = {"a": 1}
+    spec = SandboxSpec("engine", [], {})
+    provider = SandboxProvider(lambda: marker, spec)
+    # callable -> in-process build path (backward-compatible with plain builder callables)
+    assert provider() is marker
+    assert provider.build() is marker
+    # spec -> serializable rebuild path for isolated workers
+    assert provider.spec() is spec
+
+
+def test_unknown_flavor_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        SandboxSpec("bogus", [], {}).build()

--- a/tests/template/test_subprocess_render_backend.py
+++ b/tests/template/test_subprocess_render_backend.py
@@ -87,9 +87,14 @@ def _engine_provider():
     )
 
 
+def _local_backend(**kwargs):
+    # Portable process/IPC tests; actual no-network requirements are tested separately.
+    return SubprocessPoolRenderBackend(no_network=False, **kwargs)
+
+
 @pytest.fixture
 def backend():
-    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0)
+    b = _local_backend(pool_size=1, max_uses=1000, timeout=10.0)
     try:
         yield b
     finally:
@@ -110,7 +115,7 @@ def test_subprocess_backend_reuses_warm_worker(backend):
 
 
 def test_subprocess_backend_recycles_after_max_uses():
-    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1, timeout=10.0)
+    b = _local_backend(pool_size=1, max_uses=1, timeout=10.0)
     try:
         r1 = b.render("${probe()}", {"probe": _worker_pid_probe}, _engine_provider())
         r2 = b.render("${probe()}", {"probe": _worker_pid_probe}, _engine_provider())
@@ -121,7 +126,7 @@ def test_subprocess_backend_recycles_after_max_uses():
 
 def test_subprocess_backend_scrubs_credentials_from_env():
     os.environ["MAKO_TEST_APP_SECRET"] = "topsecret"
-    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0)
+    b = _local_backend(pool_size=1, max_uses=1000, timeout=10.0)
     try:
         result = b.render("${probe()}", {"probe": _read_scrubbed_env}, _engine_provider())
         assert result == "<absent>"  # 子进程启动即清洗掉了凭证类 env
@@ -131,7 +136,7 @@ def test_subprocess_backend_scrubs_credentials_from_env():
 
 
 def test_subprocess_backend_timeout_returns_inert_without_hanging():
-    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=0.5)
+    b = _local_backend(pool_size=1, max_uses=1000, timeout=0.5)
     try:
         start = time.time()
         template = "${probe()}"
@@ -145,7 +150,7 @@ def test_subprocess_backend_timeout_returns_inert_without_hanging():
 
 def test_subprocess_backend_falls_back_inprocess_on_unpicklable_context():
     # 显式 fallback_inprocess=True：threading.Lock 不可 pickle → 无法进隔离子进程 → 回退进程内、渲染正确。
-    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0, fallback_inprocess=True)
+    b = _local_backend(pool_size=1, max_uses=1000, timeout=10.0, fallback_inprocess=True)
     try:
         context = {"x": 5, "_lock": threading.Lock()}
         result = b.render("${x + 1}", context, _engine_provider())
@@ -156,7 +161,7 @@ def test_subprocess_backend_falls_back_inprocess_on_unpicklable_context():
 
 def test_subprocess_backend_strict_default_is_inert_on_unserializable():
     # 默认 strict：不可序列化 context → inert 回显模板（绝不静默回退特权进程），保安全边界。
-    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0)
+    b = _local_backend(pool_size=1, max_uses=1000, timeout=10.0)
     try:
         template = "${x + 1}"
         result = b.render(template, {"x": 5, "_lock": threading.Lock()}, _engine_provider())
@@ -174,8 +179,9 @@ def test_subprocess_backend_normalizes_rich_object_to_render_in_worker(backend):
     assert backend.render("${v}", {"v": v}, _engine_provider()) == "RichLike(2 rows)"
 
 
-def test_subprocess_backend_without_spec_uses_inprocess(backend):
-    # 传入不带 .spec() 的普通 builder（历史兼容）→ 无法隔离 → 进程内渲染（同一 PID）
+def test_subprocess_backend_without_spec_requires_explicit_fallback(backend):
+    backend.fallback_inprocess = True
+    # 仅显式 fallback 配置允许没有 spec 的 builder 回退进程内。
     parent_pid = os.getpid()
     result = backend.render("${probe()}", {"probe": _worker_pid_probe}, engine_sandbox.get)
     assert int(result) == parent_pid
@@ -190,7 +196,7 @@ def test_subprocess_backend_compile_error_is_inert(backend):
 def test_subprocess_worker_side_unpickle_failure_falls_back_fast():
     # 父进程可 pickle、worker 侧 unpickle 失败（无 __dict__ 故绕过归一化，模拟按引用重建失败的残余场景）：
     # 显式 fallback_inprocess=True 时必须快速、干净地回退进程内，而不是等满 timeout 再 inert。
-    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=2.0, fallback_inprocess=True)
+    b = _local_backend(pool_size=1, max_uses=1000, timeout=2.0, fallback_inprocess=True)
     try:
         context = {"x": 5, "_evil": _UnpicklableOnLoad()}
         start = time.time()

--- a/tests/template/test_subprocess_render_backend.py
+++ b/tests/template/test_subprocess_render_backend.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import os
+import time
+import threading
+
+import pytest
+
+from bamboo_engine.template.render_backend import (
+    PortableRenderObject,
+    SandboxProvider,
+    SandboxSpec,
+    SubprocessPoolRenderBackend,
+    _portable_context,
+)
+from bamboo_engine.template import sandbox as engine_sandbox
+
+
+# ---- module-level, picklable probes injected into render context (spawn needs top-level refs) ----
+
+
+def _worker_pid_probe():
+    return os.getpid()
+
+
+def _read_scrubbed_env():
+    # 若 env 未被清洗，这里会读到父进程注入的 "topsecret"。
+    return os.environ.get("MAKO_TEST_APP_SECRET", "<absent>")
+
+
+def _slow_probe():
+    time.sleep(5)
+    return "done"
+
+
+def _raise_on_unpickle():
+    raise RuntimeError("boom on unpickle in worker")
+
+
+class _UnpicklableOnLoad(object):
+    """父进程可 pickle、worker 侧 loads 抛错，且**无 __dict__**（不会被归一化拦截）。
+
+    用 ``__slots__=()`` + ``__reduce__`` 指向一个 load 时抛错的模块级函数，精确重现「可 pickle 但 worker
+    无法重建」这一残余失败模式（归一化只处理属性包，管不到这种无 __dict__ 的按引用重建对象）。
+    """
+
+    __slots__ = ()
+
+    def __reduce__(self):
+        return (_raise_on_unpickle, ())
+
+
+class _RichLikeVar(object):
+    """模拟 bk-sops rich 内置变量：属性包 + ``__repr__``，且 ``__setstate__`` 抛错。
+
+    若隔离 backend 未归一化就直接 pickle 原对象，worker unpickle 会触发 ``__setstate__`` 报错；因此
+    「渲染出正确结果」本身就证明 worker 只见到了归一化后的 :class:`PortableRenderObject`，从未 unpickle 原类。
+    """
+
+    def __init__(self):
+        self.col = ["a", "b"]
+        self.flat__col = "a\nb"
+
+    def __repr__(self):
+        return "RichLike(2 rows)"
+
+    def __setstate__(self, state):
+        raise RuntimeError("original rich object must not be unpickled in worker")
+
+
+def _engine_provider():
+    """engine flavor provider：进程内构造 + 可序列化 spec（供 worker 本地重建）。"""
+    return SandboxProvider(
+        engine_sandbox.get,
+        SandboxSpec("engine", [], {}),
+    )
+
+
+@pytest.fixture
+def backend():
+    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0)
+    try:
+        yield b
+    finally:
+        b.close()
+
+
+def test_subprocess_backend_renders_in_a_different_process(backend):
+    parent_pid = os.getpid()
+    result = backend.render("${probe()}", {"probe": _worker_pid_probe}, _engine_provider())
+    assert result.isdigit()
+    assert int(result) != parent_pid  # 证明渲染发生在隔离子进程里
+
+
+def test_subprocess_backend_reuses_warm_worker(backend):
+    r1 = backend.render("${probe()}", {"probe": _worker_pid_probe}, _engine_provider())
+    r2 = backend.render("${probe()}", {"probe": _worker_pid_probe}, _engine_provider())
+    assert r1 == r2  # pool_size=1 且 max_uses 很大 → 同一 warm worker 复用
+
+
+def test_subprocess_backend_recycles_after_max_uses():
+    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1, timeout=10.0)
+    try:
+        r1 = b.render("${probe()}", {"probe": _worker_pid_probe}, _engine_provider())
+        r2 = b.render("${probe()}", {"probe": _worker_pid_probe}, _engine_provider())
+        assert r1 != r2  # max_uses=1 → 每次渲染后回收，PID 不同
+    finally:
+        b.close()
+
+
+def test_subprocess_backend_scrubs_credentials_from_env():
+    os.environ["MAKO_TEST_APP_SECRET"] = "topsecret"
+    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0)
+    try:
+        result = b.render("${probe()}", {"probe": _read_scrubbed_env}, _engine_provider())
+        assert result == "<absent>"  # 子进程启动即清洗掉了凭证类 env
+    finally:
+        b.close()
+        os.environ.pop("MAKO_TEST_APP_SECRET", None)
+
+
+def test_subprocess_backend_timeout_returns_inert_without_hanging():
+    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=0.5)
+    try:
+        start = time.time()
+        template = "${probe()}"
+        result = b.render(template, {"probe": _slow_probe}, _engine_provider())
+        elapsed = time.time() - start
+        assert result == template  # 超时 → inert 回显原始模板（绝不回退进程内，避免把 DoS 带回主进程）
+        assert elapsed < 4  # 及时超时，未被拖挂
+    finally:
+        b.close()
+
+
+def test_subprocess_backend_falls_back_inprocess_on_unpicklable_context():
+    # 显式 fallback_inprocess=True：threading.Lock 不可 pickle → 无法进隔离子进程 → 回退进程内、渲染正确。
+    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0, fallback_inprocess=True)
+    try:
+        context = {"x": 5, "_lock": threading.Lock()}
+        result = b.render("${x + 1}", context, _engine_provider())
+        assert result == "6"
+    finally:
+        b.close()
+
+
+def test_subprocess_backend_strict_default_is_inert_on_unserializable():
+    # 默认 strict：不可序列化 context → inert 回显模板（绝不静默回退特权进程），保安全边界。
+    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=10.0)
+    try:
+        template = "${x + 1}"
+        result = b.render(template, {"x": 5, "_lock": threading.Lock()}, _engine_provider())
+        assert result == template
+    finally:
+        b.close()
+
+
+def test_subprocess_backend_normalizes_rich_object_to_render_in_worker(backend):
+    # rich 属性包（__setstate__ 抛错）：归一化后 worker 只见 PortableRenderObject，仍能渲染属性 + bare ${var}。
+    # 默认 strict 后端：若归一化失效则会 inert；因此渲染出正确值即证明归一化生效。
+    v = _RichLikeVar()
+    assert backend.render("${v.flat__col}", {"v": v}, _engine_provider()) == "a\nb"
+    assert backend.render("${v.col[0]}", {"v": v}, _engine_provider()) == "a"
+    assert backend.render("${v}", {"v": v}, _engine_provider()) == "RichLike(2 rows)"
+
+
+def test_subprocess_backend_without_spec_uses_inprocess(backend):
+    # 传入不带 .spec() 的普通 builder（历史兼容）→ 无法隔离 → 进程内渲染（同一 PID）
+    parent_pid = os.getpid()
+    result = backend.render("${probe()}", {"probe": _worker_pid_probe}, engine_sandbox.get)
+    assert int(result) == parent_pid
+
+
+def test_subprocess_backend_compile_error_is_inert(backend):
+    bad = "${1 + }"
+    result = backend.render(bad, {}, _engine_provider())
+    assert result == bad  # 编译失败 → inert 回显，与进程内后端一致
+
+
+def test_subprocess_worker_side_unpickle_failure_falls_back_fast():
+    # 父进程可 pickle、worker 侧 unpickle 失败（无 __dict__ 故绕过归一化，模拟按引用重建失败的残余场景）：
+    # 显式 fallback_inprocess=True 时必须快速、干净地回退进程内，而不是等满 timeout 再 inert。
+    b = SubprocessPoolRenderBackend(pool_size=1, max_uses=1000, timeout=2.0, fallback_inprocess=True)
+    try:
+        context = {"x": 5, "_evil": _UnpicklableOnLoad()}
+        start = time.time()
+        result = b.render("${x + 1}", context, _engine_provider())
+        elapsed = time.time() - start
+        assert result == "6"  # 干净回退进程内 → 渲染正确（而非 inert "${x + 1}"）
+        assert elapsed < 1.5  # worker 立即回 STATUS_ERR → 快速回退，而非等满 2s timeout
+    finally:
+        b.close()
+
+
+def test_portable_render_object_roundtrips_via_pickle():
+    o = PortableRenderObject({"a": 1, "flat__x": "y\nz"}, "STRV", "REPRV")
+    import pickle
+
+    o2 = pickle.loads(pickle.dumps(o))
+    assert o2.a == 1 and o2.flat__x == "y\nz"
+    assert str(o2) == "STRV" and repr(o2) == "REPRV"
+
+
+def test_portable_context_preserves_plain_and_callables_normalizes_rich():
+    def f():
+        return 1
+
+    out = _portable_context({"x": 5, "s": "hi", "l": [1, {"k": "v"}], "f": f, "rich": _RichLikeVar()})
+    assert out["x"] == 5 and out["s"] == "hi"
+    assert out["l"] == [1, {"k": "v"}]  # 容器递归、plain 元素不变
+    assert out["f"] is f  # 可调用不被归一化（否则 ${f()} 会坏）
+    assert isinstance(out["rich"], PortableRenderObject)  # rich 属性包被归一化
+    assert out["rich"].flat__col == "a\nb" and str(out["rich"]) == "RichLike(2 rows)"

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -13,8 +13,14 @@ specific language governing permissions and limitations under the License.
 
 import datetime
 
+import pytest
+from mako.template import Template as MakoTemplate
+
 from bamboo_engine.config import Settings
 from bamboo_engine.template import Template
+from bamboo_engine.utils import mako_safety
+from bamboo_engine.utils.mako_utils.checker import check_mako_template_safety
+from bamboo_engine.utils.mako_utils.exceptions import ForbiddenMakoTemplateException
 
 
 def test_get_reference():
@@ -110,3 +116,214 @@ def test_mako_attack():
     ]
     for at in attack_templates:
         assert Template(at).render({}) == at
+
+
+@pytest.fixture
+def whitelist_mode():
+    original_mode = Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE
+    original_extra = Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
+    def _set(mode, extra=()):
+        Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = mode
+        Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset(extra)
+
+    try:
+        yield _set
+    finally:
+        Settings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = original_mode
+        Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = original_extra
+
+
+def test_mako_self_module_namespace_executes_when_whitelist_off(whitelist_mode):
+    whitelist_mode("off")
+    payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
+    rendered = Template(payload).render({})
+    assert "OFF" in rendered
+
+
+def test_mako_whitelist_default_blocks_self_module_namespace():
+    payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+    assert Template(payload).render({}) == payload
+
+
+def _assert_forbidden_template(payload):
+    with pytest.raises(ForbiddenMakoTemplateException):
+        check_mako_template_safety(
+            payload,
+            mako_safety.SingleLineNodeVisitor(),
+            mako_safety.SingleLinCodeExtractor(),
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${self.module.cache.util.os.popen("echo PWNED").read()}',
+        "${context.lookup}",
+        "${local.something}",
+        "${parent.foo}",
+        "${caller.body()}",
+        "${pageargs.x}",
+    ],
+)
+def test_mako_whitelist_blocks_reserved_namespaces(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    assert Template(payload).render({}) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${os.path.os.popen("echo PWNED").read()}',
+        '${os.path.genericpath.os.popen("echo PWNED").read()}',
+        '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+        '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+        '${os.path.os.system("echo PWNED")}',
+    ],
+)
+def test_mako_whitelist_blocks_dangerous_attr_chain(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "re": "re",
+        "os.path": "os.path",
+    }
+    try:
+        rendered = Template({"x": payload}).render({})
+        assert rendered["x"] == payload
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${context._kwargs}",
+        "${context._with_template}",
+        "${context._data}",
+        "${obj._secret}",
+        "${obj.public._private}",
+    ],
+)
+def test_mako_whitelist_blocks_single_underscore_attr(whitelist_mode, payload):
+    whitelist_mode("enforce")
+    rendered = Template({"x": payload}).render({"obj": object()})
+    assert rendered["x"] == payload
+
+
+def test_mako_whitelist_allows_business_patterns(whitelist_mode):
+    whitelist_mode("enforce")
+    cases = [
+        ("${name.upper()}", {"name": "abc"}, "ABC"),
+        ("${name.split('-')}", {"name": "a-b-c"}, "['a', 'b', 'c']"),
+        ("${[x * 2 for x in items]}", {"items": [1, 2, 3]}, "[2, 4, 6]"),
+        ("${(lambda y: y + 1)(seed)}", {"seed": 4}, "5"),
+        ("${a if a else 'default'}", {"a": ""}, "default"),
+        ("${len(items)}", {"items": [1, 2, 3]}, "3"),
+    ]
+    for tpl, ctx, expected in cases:
+        assert Template(tpl).render(ctx) == expected
+
+
+def test_mako_whitelist_allows_imported_modules(whitelist_mode):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "os.path": "os.path",
+    }
+    try:
+        assert Template('${os.path.join("a", "b")}').render({}) == "a/b"
+        out = Template('${datetime.datetime.now().strftime("%Y")}').render({})
+        assert len(out) == 4 and out.isdigit()
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+def test_mako_whitelist_extra_names_allowed(whitelist_mode):
+    whitelist_mode("enforce", extra=("_loop", "_system"))
+    assert Template("${_loop}").render({"_loop": 7}) == 7
+    assert Template("${_loop + 1}").render({"_loop": 2}) == "3"
+
+
+def test_mako_whitelist_unknown_root_name_is_blocked(whitelist_mode):
+    whitelist_mode("enforce")
+    payload = "${secret_var}"
+    assert Template(payload).render({}) == payload
+
+
+def test_mako_filter_side_effect_expression_is_blocked():
+    _assert_forbidden_template("${'x'|((side_effect() or str))}")
+
+
+def test_mako_filter_dunder_chain_is_blocked():
+    _assert_forbidden_template("${'x'|().__class__.__bases__[0].__subclasses__}")
+
+
+def test_mako_filter_list_blocks_any_malicious_item():
+    _assert_forbidden_template("${'x'|h, (side_effect() or str)}")
+
+
+def test_mako_decode_filter_private_attribute_is_blocked():
+    _assert_forbidden_template("${'x'|decode.__class__}")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '<%page expression_filter="(side_effect() or str)"/>${name}',
+        '<%def name="render_name(name)" filter="(side_effect() or str)">${name}</%def>${render_name("x")}',
+        '<%block filter="(side_effect() or str)">x</%block>',
+        '<%text filter="(side_effect() or str)">x</%text>',
+    ],
+)
+def test_mako_tag_filter_callables_are_blocked(payload):
+    _assert_forbidden_template(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${' x ' | h}",
+        "${' x ' | trim}",
+        "${' x ' | h, trim}",
+        "${'x' | n}",
+        "${b'abc' | decode.utf8}",
+    ],
+)
+def test_mako_builtin_filters_remain_allowed(payload):
+    check_mako_template_safety(
+        payload,
+        mako_safety.SingleLineNodeVisitor(),
+        mako_safety.SingleLinCodeExtractor(),
+    )
+
+
+def test_mako_builtin_filter_rendering_still_works():
+    assert MakoTemplate("${'x' | h}").render_unicode() == "x"
+    assert MakoTemplate("${' x ' | trim}").render_unicode() == "x"
+
+
+def test_mako_filter_side_effect_is_not_executed_by_template_render():
+    sentinel = {"called": False}
+
+    def side_effect():
+        sentinel["called"] = True
+        return str
+
+    payload = "${'x'|((side_effect() or str))}"
+
+    assert Template(payload).render({"side_effect": side_effect}) == payload
+    assert sentinel["called"] is False
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${"{0.__class__}".format("")}',
+        '${"{value.__class__}".format_map({"value": ""})}',
+    ],
+)
+def test_mako_format_private_lookup_is_blocked(payload):
+    _assert_forbidden_template(payload)

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -81,7 +81,10 @@ def test_render__with_sandbox():
     r2 = Template("""${datetime.datetime.now().strftime("%Y")}""").render({})
     assert r2 == """${datetime.datetime.now().strftime("%Y")}"""
 
-    Settings.MAKO_SANDBOX_IMPORT_MODULES = {"datetime": "datetime"}
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "datetime.datetime": "datetime.datetime",
+    }
 
     r2 = Template("""${datetime.datetime.now().strftime("%Y")}""").render({})
     year = datetime.datetime.now().strftime("%Y")
@@ -196,19 +199,26 @@ def test_mako_whitelist_blocks_dangerous_attr_chain(whitelist_mode, payload):
         Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
 
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        "${context._kwargs}",
-        "${context._with_template}",
-        "${context._data}",
-        "${obj._secret}",
-        "${obj.public._private}",
-    ],
-)
-def test_mako_whitelist_blocks_single_underscore_attr(whitelist_mode, payload):
+def test_mako_whitelist_allows_user_single_underscore_attr(whitelist_mode):
     whitelist_mode("enforce")
-    rendered = Template({"x": payload}).render({"obj": object()})
+
+    class Bag(object):
+        def __init__(self):
+            self._module = [{"gamesvr": "1.1.1.1"}]
+
+    out = Template("${obj._module[0]['gamesvr']}").render({"obj": Bag()})
+    assert out == "1.1.1.1"
+
+
+def test_mako_whitelist_allows_bare_reserved_name(whitelist_mode):
+    whitelist_mode("enforce")
+    assert Template("${parent + ''}").render({"parent": "alice"}) == "alice"
+
+
+def test_mako_whitelist_blocks_self_module_even_if_self_in_context(whitelist_mode):
+    whitelist_mode("enforce")
+    payload = '${self.module.cache.util.os.popen("echo PWNED").read()}'
+    rendered = Template({"x": payload}).render({"self": "ignored"})
     assert rendered["x"] == payload
 
 
@@ -231,12 +241,31 @@ def test_mako_whitelist_allows_imported_modules(whitelist_mode):
     original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
     Settings.MAKO_SANDBOX_IMPORT_MODULES = {
         "datetime": "datetime",
+        "datetime.datetime": "datetime.datetime",
         "os.path": "os.path",
+        "json": "json",
+        "hashlib": "hashlib",
     }
     try:
         assert Template('${os.path.join("a", "b")}').render({}) == "a/b"
         out = Template('${datetime.datetime.now().strftime("%Y")}').render({})
         assert len(out) == 4 and out.isdigit()
+        assert Template("${json.dumps({'a': 1})}").render({})
+        digest = Template("${hashlib.md5(b'x').hexdigest()}").render({})
+        assert len(digest) == 32
+        deep = "${json.codecs.builtins.exec('1')}"
+        assert Template({"x": deep}).render({})["x"] == deep
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+def test_mako_whitelist_datetime_now_requires_configured_class_alias(whitelist_mode):
+    whitelist_mode("enforce")
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {"datetime": "datetime"}
+    try:
+        payload = '${datetime.datetime.now().strftime("%Y")}'
+        assert Template({"x": payload}).render({})["x"] == payload
     finally:
         Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
 

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -356,3 +356,58 @@ def test_mako_filter_side_effect_is_not_executed_by_template_render():
 )
 def test_mako_format_private_lookup_is_blocked(payload):
     _assert_forbidden_template(payload)
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "gi_frame",
+        "gi_code",
+        "cr_frame",
+        "ag_frame",
+        "f_back",
+        "f_builtins",
+        "f_globals",
+        "f_locals",
+        "f_code",
+        "tb_frame",
+        "tb_next",
+        "func_globals",
+    ],
+)
+def test_mako_frame_introspection_attr_is_blocked(attr):
+    # 无论根对象是什么，通向 frame 的反射属性名一律在 always-on 的 SingleLineNodeVisitor 拒绝。
+    _assert_forbidden_template("${obj.%s}" % attr)
+
+
+def test_mako_generator_frame_builtins_gadget_is_inert_in_all_modes(whitelist_mode):
+    # 生成器帧 -> 真实 builtins -> eval 的通用 RCE：off / warn / enforce 三档都必须拦。
+    payload = (
+        "${(i for i in [1]).gi_frame.f_builtins['eval']"
+        "(\"__import__('os').popen('echo PWNED').read()\")}"
+    )
+    for mode in ("off", "warn", "enforce"):
+        whitelist_mode(mode)
+        assert Template(payload).render({}) == payload
+
+
+def test_restricted_builtins_strips_execution_primitives():
+    from bamboo_engine.template import sandbox
+
+    rb = sandbox.restricted_builtins()
+    for name in ("eval", "exec", "compile", "open", "input", "breakpoint"):
+        assert name not in rb
+    # 不能误伤 Mako codegen / 业务表达式需要的安全内建，以及 C 扩展惰性 import 依赖的 __import__。
+    for name in ("len", "str", "range", "int", "dict", "enumerate", "__import__"):
+        assert name in rb
+
+
+def test_harden_template_builtins_is_defense_in_depth(whitelist_mode, monkeypatch):
+    # 模拟未来某条未被枚举到的"通向 frame"链路：临时清空属性 deny-list，证明即便 AST 放过，
+    # 渲染期受限 builtins 也已摘掉 eval，攻击者拿不到执行原语；同时不影响安全内建（len）。
+    whitelist_mode("off")
+    monkeypatch.setattr(mako_safety, "FRAME_INTROSPECTION_ATTRS", frozenset())
+    pwn = "${(i for i in [1]).gi_frame.f_builtins['eval']('1+1')}"
+    assert Template(pwn).render({}) == pwn
+    safe = "${(i for i in [1]).gi_frame.f_builtins['len']([1, 2, 3])}"
+    assert Template(safe).render({}) == "3"

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -137,11 +137,13 @@ def whitelist_mode():
         Settings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = original_extra
 
 
-def test_mako_self_module_namespace_executes_when_whitelist_off(whitelist_mode):
-    whitelist_mode("off")
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+def test_mako_self_module_namespace_blocked_in_all_modes(whitelist_mode, mode):
+    # 保留命名空间属性链下沉到 always-on 层后，off / warn 也不再解析出真实模块，
+    # 经典 ``${self.module.cache.util.os...}`` 链在所有模式下都 inert。
+    whitelist_mode(mode)
     payload = '${self.module.cache.util.os.popen("echo OFF").read()}'
-    rendered = Template(payload).render({})
-    assert "OFF" in rendered
+    assert Template(payload).render({}) == payload
 
 
 def test_mako_whitelist_default_blocks_self_module_namespace():
@@ -411,3 +413,89 @@ def test_harden_template_builtins_is_defense_in_depth(whitelist_mode, monkeypatc
     assert Template(pwn).render({}) == pwn
     safe = "${(i for i in [1]).gi_frame.f_builtins['len']([1, 2, 3])}"
     assert Template(safe).render({}) == "3"
+
+
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '${os.path.os.system("echo PWNED")}',
+        '${os.path.genericpath.os.popen("echo PWNED").read()}',
+        '${datetime.sys.modules["os"].popen("echo PWNED").read()}',
+        '${re.enum.sys.modules["os"].popen("echo PWNED").read()}',
+        '${json.codecs.builtins.exec("import os")}',
+    ],
+)
+def test_mako_dangerous_attr_chain_blocked_in_all_modes(whitelist_mode, mode, payload):
+    # 危险属性名下沉 always-on 后，模块反向 pivot 在 off / warn / enforce 三档都 inert，
+    # 不再依赖白名单模式（此前 off 模式可直接拿到真实 os / builtins 模块执行命令）。
+    whitelist_mode(mode)
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "datetime": "datetime",
+        "re": "re",
+        "os.path": "os.path",
+        "json": "json",
+    }
+    try:
+        assert Template({"x": payload}).render({})["x"] == payload
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports
+
+
+@pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "${context.lookup}",
+        "${local.something}",
+        "${parent.foo}",
+        "${caller.body()}",
+        "${pageargs.x}",
+    ],
+)
+def test_mako_reserved_namespace_chain_blocked_in_all_modes(whitelist_mode, mode, payload):
+    # 保留命名空间属性链（即使不以危险属性收尾）在所有模式下 inert。
+    whitelist_mode(mode)
+    assert Template(payload).render({}) == payload
+
+
+def test_filter_import_modules_rejects_dangerous_keeps_safe():
+    from bamboo_engine.template import sandbox
+
+    src = {
+        "os": "os",
+        "subprocess": "subprocess",
+        "operator": "operator",
+        "pickle": "pickle",
+        "importlib": "importlib",
+        "ctypes": "ctypes",
+        "os.path": "os.path",
+        "json": "json",
+        "re": "re",
+    }
+    safe = sandbox.filter_import_modules(src)
+    # 危险模块被拒绝；os.path（安全子模块）与普通模块保留。
+    assert set(safe) == {"os.path", "json", "re"}
+
+
+def test_sandbox_get_does_not_expose_dangerous_module():
+    from bamboo_engine.template import sandbox
+
+    original_imports = Settings.MAKO_SANDBOX_IMPORT_MODULES
+    Settings.MAKO_SANDBOX_IMPORT_MODULES = {
+        "os": "os",
+        "subprocess": "subprocess",
+        "os.path": "os.path",
+        "json": "json",
+    }
+    try:
+        data = sandbox.get()
+        # 直接注入的 os / subprocess 被 deny-list 拦掉，不进入渲染命名空间。
+        assert "subprocess" not in data
+        assert getattr(data.get("os"), "system", None) is None
+        # os.path 仍作为 ModuleObject 暴露 join 等安全路径操作；普通模块保留。
+        assert data.get("os") is not None and hasattr(data["os"], "path")
+        assert "json" in data
+    finally:
+        Settings.MAKO_SANDBOX_IMPORT_MODULES = original_imports

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -352,7 +352,6 @@ def test_mako_filter_side_effect_is_not_executed_by_template_render():
 @pytest.mark.parametrize(
     "payload",
     [
-        '${"{0.__class__}".format("")}',
         '${"{value.__class__}".format_map({"value": ""})}',
     ],
 )


### PR DESCRIPTION
## 问题与行为

新增可选的 Mako 子进程渲染后端，engine 与 legacy 共用渲染入口。默认仍为 `MAKO_RENDER_BACKEND="inprocess"`，只有接入方显式配置 `subprocess` 才启用。本 PR 保持 Draft。

原隔离实现存在五类已复现问题：daemon/prefork 宿主无法启动 worker、父进程执行 worker 回复中的 pickle、rich context 被有损转换、替换 worker 失败后池容量丢失，以及超时不覆盖启动/排队/完整通信。本次已修复这些问题，并补充并发关闭、取消和 fork 生命周期回归。

## 实现

- 使用独立 Python 解释器与每槽位一个持久监督线程启动 worker，兼容 daemon/prefork；不重新导入宿主 `__main__`。启动前环境变量采用白名单、禁用 site 钩子、关闭无关文件描述符。
- worker 回复改为带版本、请求 ID、状态和字符串结果的受限 JSON。主进程不执行 worker pickle；校验固定头、字段类型、长度及请求 ID，拒绝重放、嵌套对象和超长数字。请求和回复均限制帧长，READY 握手后才发送业务 context。
- 排队、准备、启动、握手、发送和接收共用 monotonic deadline。启动阻塞后原槽位继续被占用，晚到进程会被回收，后台启动线程数量不随超时次数增长。
- 成功结果不受回收/补启动失败覆盖；替代 worker 在下一请求懒启动。未完成回收的 worker 保留槽位，确认退出后才归队，防止进程数量超出池容量。
- 明确保留支持的普通类型、`time.struct_time`、`Counter` 等语义。仅结构化属性包转换为可移植对象；property、方法、未知容器子类等不再被静默抹掉，而是进入明确的不支持路径。限制对象图深度、元素数和内容大小并拒绝环。
- strict 默认关闭进程内回退，无 spec 同样遵循策略。显式兼容回退仅允许主进程确认的 context/spec 问题；worker、协议、超时和隔离失败不能强迫宿主渲染。
- `no_network=True` 要求 Linux network namespace 成功建立，权限不足或平台不支持即失败关闭。Linux 资源限制同时降低 soft/hard 上限；独立进程组回收与父线程死亡信号覆盖 worker 生命周期。
- fork 后在接触继承锁之前重建状态，只关闭父连接的本地副本，包括正在 Popen 构造中的连接。关闭覆盖全部槽位，调用方中断会取消对应 job；旧 job 的延迟取消不会误杀下一请求的 worker。

## 与 #284 的关系

依赖 #284 的安全检查和沙箱改动，仍按 #284 → #285 顺序合入。本分支已经合入 #284 的兼容性修复 `9861528`；隔离后端修复提交为 `3da9ded`。两个 PR 的 GitHub 目标分支均为 `bamboo_pipeline_3.24_lts`。

关联 TAPD：`--story=137948769`。

## 验证

2026-09-07 对 `3da9ded` 的本地验证：

- Python 3.6.15：完整 engine tests **399 passed, 1 skipped**。
- Python 3.7.16：完整 engine tests **399 passed, 1 skipped**。
- legacy expression / sandbox / sandbox_builder：**63 passed**。
- 真实 billiard prefork daemon 中渲染 `${x+1}` 返回 `3`。
- engine 与 legacy 实际 subprocess 渲染入口通过，包含 legacy mock builtin 行为。
- 覆盖恶意 pickle 回复、错序回复、半包/慢速回复、大请求发送阻塞、启动与排队超时、回收失败恢复、未回收槽位、并发复用、关闭竞争、调用取消及真实 fork。
- 修改文件 flake8、Black 和 diff whitespace 检查通过；独立复核确认最后四项生命周期修复。

本地为 macOS；跳过的是 Linux 资源限制测试，不代表已验证生产 Linux 容器权限或业务回归。GitHub Actions 状态以当前提交实际运行结果为准。

## 配置与隔离边界

详见 `docs/mako-render-backend.md`。宿主仍需把配置接入 `bamboo_engine.config.Settings`；本库不会自动读取同名环境变量。

环境白名单和 network namespace **不等同于无凭证容器沙箱**：文件系统、身份、挂载凭证、导入模块、路径型 Unix socket、主动脱离进程组的后代仍需部署层约束；warm worker 也不提供不同请求间的强隔离。请求侧 pickle 仅接受受信任服务端构造的对象，不能暴露为外部输入接口。显式进程内兼容回退不具备隔离后端的资源/安全保证。

依赖包按既定发布顺序同步更新；本次没有新增版本变更，也没有启用生产隔离后端。
