### PR TITLE
chore(release): prepare engine 2.6.7 and stabilize pool test

### DIFF
--- a/bamboo_engine/__version__.py
+++ b/bamboo_engine/__version__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-__version__ = "2.6.6"
+__version__ = "2.6.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-engine"
-version = "2.6.6"
+version = "2.6.7"
 description = "Bamboo-engine is a general-purpose workflow engine"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"

--- a/tests/template/test_render_backend_failures.py
+++ b/tests/template/test_render_backend_failures.py
@@ -268,7 +268,7 @@ def test_pool_concurrent_requests_return_their_own_results():
 
 
 def test_unreaped_worker_keeps_its_slot(monkeypatch):
-    backend = pool(timeout=0.2, max_uses=1)
+    backend = pool(max_uses=1)
     entered = threading.Event()
     release = threading.Event()
     stop = rb._RenderWorker.stop
@@ -284,6 +284,8 @@ def test_unreaped_worker_keeps_its_slot(monkeypatch):
     try:
         assert backend.render("${x+1}", {"x": 2}, provider()) == "3"
         assert entered.wait(1)
+        # The short deadline tests admission while reaping, not worker startup.
+        backend.timeout = 0.2
         assert backend.render("${x+1}", {"x": 2}, provider()) == "${x+1}"
     finally:
         release.set()


### PR DESCRIPTION
# 变更

为已合入 3.24 LTS 的 #285 准备 bamboo-engine 2.6.7，更新两处版本号。

修复 #285 CI 中进程回收测试的启动时序依赖：原测试将冷启动和等待空闲位置都限制为 0.2 秒，在较慢 runner 上会在首次渲染时误报。首次渲染使用测试工具的正常超时，只在确认进入回收后，将下一次调用的等待限制为 0.2 秒，继续验证未回收的进程占用池位置。

# 验证

- 注入 0.3 秒慢启动，原测试失败，修正后通过。
- Python 3.6、3.7 的 coverage 测试运行均为 399 passed、1 skipped。
- Poetry 配置检查和构建通过；wheel 中全部 64 个 Python 源码文件与当前提交一致。
- engine 发布成功后，继续更新 pipeline 依赖及 lock 并发布 3.24.18。
