### PR TITLE
chore(release): prepare pipeline 3.24.18

### DIFF
--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "3.24.17"
+__version__ = "3.24.18"

--- a/runtime/bamboo-pipeline/poetry.lock
+++ b/runtime/bamboo-pipeline/poetry.lock
@@ -66,11 +66,11 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "bamboo-engine"
-version = "2.6.6"
+version = "2.6.7"
 description = "Bamboo-engine is a general-purpose workflow engine"
 category = "main"
 optional = false
-python-versions = ">=3.6,<3.8"
+python-versions = "<3.8,>=3.6"
 
 [package.dependencies]
 Mako = ">=1.1.4,<2.0.0"
@@ -811,7 +811,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">= 3.6, < 3.8"
-content-hash = "ace65a15ac0c2ac291de0d5971effb7a3c41276397bbd95a211ada2c33726812"
+content-hash = "4a60749403e77803fec09f43f1b7a0b3e89722d19decbf5134c19f4038c19382"
 
 [metadata.files]
 amqp = []
@@ -824,8 +824,8 @@ async-timeout = []
 atomicwrites = []
 attrs = []
 bamboo-engine = [
-    {file = "bamboo_engine-2.6.6-py3-none-any.whl", hash = "sha256:980390778e08b8aa34909ce8cd94b4fc1a09560e329c7094ab9fc6e5b29801a6"},
-    {file = "bamboo_engine-2.6.6.tar.gz", hash = "sha256:bb5ca26d89acfb07547e84ec005a14202f5e5ad8db2a2c29b26e924fa1cec4e1"},
+    {file = "bamboo_engine-2.6.7-py3-none-any.whl", hash = "sha256:99f1bd2d1df04374a744324486fb6c2fae857747d7748a1b7c01259fa127f518"},
+    {file = "bamboo_engine-2.6.7.tar.gz", hash = "sha256:15b54106de64cce6b0b0b9f36445cb6a14541262fee511a5553e4549171d268a"},
 ]
 billiard = []
 black = []

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "3.24.17"
+version = "3.24.18"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"
@@ -16,7 +16,7 @@ requests = "^2.22"
 django-celery-beat = "^2.1"
 Mako = "^1.1.4"
 pytz = ">=2019.3"
-bamboo-engine = "2.6.6"
+bamboo-engine = "2.6.7"
 jsonschema = "^2.5.1"
 ujson = "^4"
 pyparsing = "^2.2"

--- a/runtime/bamboo-pipeline/test/eri_imp_test_use/tests/control/test_pause_and_resume_pipeline.py
+++ b/runtime/bamboo-pipeline/test/eri_imp_test_use/tests/control/test_pause_and_resume_pipeline.py
@@ -182,13 +182,13 @@ def test_pause_and_resume_pipeline_with_subprocess_has_parallel():
 
     for _ in range(parallel_count):
         act = ServiceActivity(component_code="sleep_timer")
-        act.component.inputs.bk_timing = Var(type=Var.PLAIN, value=3)
+        act.component.inputs.bk_timing = Var(type=Var.PLAIN, value=30)
         sleep_group_1.append(act)
 
     sleep_group_2 = []
     for _ in range(parallel_count):
         act = ServiceActivity(component_code="sleep_timer")
-        act.component.inputs.bk_timing = Var(type=Var.PLAIN, value=3)
+        act.component.inputs.bk_timing = Var(type=Var.PLAIN, value=30)
         sleep_group_2.append(act)
 
     acts_group_1 = [ServiceActivity(component_code="debug_node") for _ in range(parallel_count)]
@@ -216,7 +216,9 @@ def test_pause_and_resume_pipeline_with_subprocess_has_parallel():
     engine = Engine(runtime)
     engine.run_pipeline(pipeline=pipeline, root_pipeline_data={})
 
-    sleep(2)
+    # Wait for every branch to start before pausing. The timers leave room
+    # for startup on slower runners and finish while the pipeline is paused.
+    assert_all_running([a.id for a in sleep_group_1 + sleep_group_2])
 
     engine.pause_pipeline(pipeline["id"])
 


### PR DESCRIPTION
# 变更

为已合入 3.24 LTS 的 #285 发布 bamboo-pipeline 3.24.18。同步两处版本号，将 bamboo-engine 依赖和 lock 更新为已发布的 2.6.7，使安装后的环境包含新的渲染后端及传输模块。

修正含并行子流程的暂停/恢复集成用例：原用例在启动 2 秒后直接暂停，并假设所有 10 个定时节点都已启动；较慢 runner 上部分分支尚未创建，暂停后这些分支保持未执行，导致错误的 FINISHED 断言。改为等待所有定时节点进入 RUNNING 后再暂停，并为分支启动预留定时窗口。保留定时节点在暂停期间完成、下游保持未执行、恢复后整个流程完成的全部断言。

# 验证

- bamboo-engine 2.6.7 发布工作流成功，PyPI wheel/sdist 哈希和全部源码已核验；干净环境安装后的子进程基础渲染通过。
- Poetry 1.1.14 的 lock --no-update 已执行；保留生成的 engine 元数据和哈希，其余锁定条目保持原样。
- 配置检查、lock freshness、安装解析（dry run）和本地构建通过；产物包含 sandbox_builder 模块，依赖为 bamboo-engine ==2.6.7。
- 暂停用例修正后，Python 3.6/3.7 语法检查通过；本 PR 继续执行完整 CI，通过后发布 bamboo-pipeline 3.24.18。
