### PR TITLE
bugfix: 修复 AI 审查输出截断及 LTS 接入检测

### DIFF
--- a/.ai/review/README.md
+++ b/.ai/review/README.md
@@ -6,12 +6,14 @@
 
 - PR 新建、更新、重新打开或退出草稿时运行；PR 作者和事件发起人都必须拥有仓库 write/maintain/admin 权限。外部贡献者的 PR 会明确跳过，可由维护者人工审查；不能靠加标签放开凭据。
 - 管理员在 GitHub 仓库 Actions Secrets 中配置 `CODEBUDDY_API_KEY`，值为公司 CodeBuddy API key；不使用 OpenClaw OAuth token。缺少或失效会失败，不发布“无问题”结论。密钥到期前由维护者更新该 Secret。
-- `pull_request_target` 只执行目标分支代码和知识库。当前接入 PR 合入前，不能据此 PR 的检查证明自动模型审查已生效；后续 PR 事件才会加载本方案。
+- `pull_request_target` 从仓库默认分支读取工作流；本工作流再显式检出 PR Base SHA，只执行该目标分支已合入的审查脚本和知识。接入 PR 的检查不证明其 head 配置已经生效；后续 PR 事件才会加载已合入的方案。
 - 不创建自动合入、自动批准或发布任务；暂不把 AI 判断设为必需合入门禁。
 
 ## LTS 与开发分支覆盖
 
-工作流、审查脚本和知识规则必须分别合入每条需要接收 PR 的目标分支。主分支已经接入、工作流没有 `branches` 过滤，都不意味着其他 LTS 自动获得这套检查。新建或保留维护分支时，应将这六份接入文件一起补齐，并按照该分支的真实模块、版本和兼容约束调整知识与规则。
+默认分支的工作流是全仓触发入口；每条 PR 目标分支还必须拥有审查脚本和知识规则。默认分支已经接入、工作流没有 `branches` 过滤，都不意味着其他 LTS 自动获得完整审查。新建或保留维护分支时，将六份接入文件一起补齐，并按该分支真实模块、版本和兼容约束调整知识与规则；各分支的工作流副本供维护回移使用，当前执行入口仍来自默认分支。
+
+目标 base 完全没有审查脚本/两份规则时，工作流明确标记尚未接入并跳过模型调用；仅缺少部分文件则失败，避免不完整配置静默运行。合入 LTS 的完整接入文件后，后续事件才执行该 LTS 的审查。工作流逻辑变更还必须合入默认分支，单独修改 LTS 的工作流副本不会改变当前入口。
 
 仓库级 `CODEBUDDY_API_KEY` Secret 由同一仓库的分支共享，无需逐分支创建。合入后用新的维护 PR 验证 `review` 调用模型、`publish` 发布对应 head 的评论；仅 `validate` 通过只能证明 runner 单测通过。已有 PR 不会因目标分支补接入而自动重跑，需要后续更新、重新打开或退出草稿事件。
 
@@ -39,4 +41,4 @@ python3 -I -m unittest discover -s .github/scripts -p test_ai_review.py -v
 
 该测试不需要模型凭据，覆盖 diff 定位、返回结构、链接与提及转义、路径穿越/符号链接、export-ignore/export-subst、特殊文件名、过期结果和评论更新；同时验证模型进程不继承 GitHub 凭据、runner 命令文件和外部工具授权，以及超过 1 MB 的 CLI JSON 在立即退出后仍完整读取。工作流的 `pull_request` 校验 job 不接收模型 Secret；业务代码应另按知识库列出的现有测试执行。
 
-参考：[GitHub Actions 安全指南](https://docs.github.com/en/actions/reference/security/secure-use)。
+参考：[GitHub Actions 安全指南](https://docs.github.com/en/actions/reference/security/secure-use)、[pull_request_target 默认分支语义](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)。

--- a/.ai/review/README.md
+++ b/.ai/review/README.md
@@ -9,6 +9,12 @@
 - `pull_request_target` 只执行目标分支代码和知识库。当前接入 PR 合入前，不能据此 PR 的检查证明自动模型审查已生效；后续 PR 事件才会加载本方案。
 - 不创建自动合入、自动批准或发布任务；暂不把 AI 判断设为必需合入门禁。
 
+## LTS 与开发分支覆盖
+
+工作流、审查脚本和知识规则必须分别合入每条需要接收 PR 的目标分支。主分支已经接入、工作流没有 `branches` 过滤，都不意味着其他 LTS 自动获得这套检查。新建或保留维护分支时，应将这六份接入文件一起补齐，并按照该分支的真实模块、版本和兼容约束调整知识与规则。
+
+仓库级 `CODEBUDDY_API_KEY` Secret 由同一仓库的分支共享，无需逐分支创建。合入后用新的维护 PR 验证 `review` 调用模型、`publish` 发布对应 head 的评论；仅 `validate` 通过只能证明 runner 单测通过。已有 PR 不会因目标分支补接入而自动重跑，需要后续更新、重新打开或退出草稿事件。
+
 ## 审查上下文
 
 - `.ai/review/knowledge.md`：仓库模块、依赖与协议事实。
@@ -31,6 +37,6 @@
 python3 -I -m unittest discover -s .github/scripts -p test_ai_review.py -v
 ```
 
-该测试不需要模型凭据，覆盖 diff 定位、返回结构、链接与提及转义、路径穿越/符号链接、export-ignore/export-subst、特殊文件名、过期结果和评论更新。工作流的 `pull_request` 校验 job 不接收模型 Secret；业务代码应另按知识库列出的现有测试执行。
+该测试不需要模型凭据，覆盖 diff 定位、返回结构、链接与提及转义、路径穿越/符号链接、export-ignore/export-subst、特殊文件名、过期结果和评论更新；同时验证模型进程不继承 GitHub 凭据、runner 命令文件和外部工具授权。工作流的 `pull_request` 校验 job 不接收模型 Secret；业务代码应另按知识库列出的现有测试执行。
 
 参考：[GitHub Actions 安全指南](https://docs.github.com/en/actions/reference/security/secure-use)。

--- a/.ai/review/README.md
+++ b/.ai/review/README.md
@@ -27,7 +27,7 @@
 
 最多报告 8 个有触发条件、调用链、影响和修复建议的 P1/P2 问题，用中文输出到一条可更新的 PR 评论，附本次 commit 的源码行链接。仅允许引用本次新增/删除行。重复运行更新同一评论；发布前重新检查 head 和 base，过期结果不发布。
 
-模型任务只有仓库只读权限；评论发布在独立 job 中持有 PR 写权限。仅传递验证后的结果和提交元数据，不上传原始对话、源码快照或配置目录。Actions 固定到提交 SHA，CLI 固定 `@tencent-ai/codebuddy-code@2.147.0`。
+模型任务只有仓库只读权限；评论发布在独立 job 中持有 PR 写权限。CLI 原始输出由私有临时文件接收，避免进程退出时尚未写完的管道造成长 JSON 截断；文件关闭即删除。仅传递验证后的结果和提交元数据，不上传原始对话、源码快照或配置目录。Actions 固定到提交 SHA，CLI 固定 `@tencent-ai/codebuddy-code@2.147.0`。
 
 模型调用、JSON 校验或凭据失败会使检查失败；查看失败步骤处理，不能据“没有评论”认定通过。更新依赖或约束后先跑下列验证，再用正常业务 PR 检查结果。AI 输出有误由人工判定，修正知识规则后随 PR 更新重跑。
 
@@ -37,6 +37,6 @@
 python3 -I -m unittest discover -s .github/scripts -p test_ai_review.py -v
 ```
 
-该测试不需要模型凭据，覆盖 diff 定位、返回结构、链接与提及转义、路径穿越/符号链接、export-ignore/export-subst、特殊文件名、过期结果和评论更新；同时验证模型进程不继承 GitHub 凭据、runner 命令文件和外部工具授权。工作流的 `pull_request` 校验 job 不接收模型 Secret；业务代码应另按知识库列出的现有测试执行。
+该测试不需要模型凭据，覆盖 diff 定位、返回结构、链接与提及转义、路径穿越/符号链接、export-ignore/export-subst、特殊文件名、过期结果和评论更新；同时验证模型进程不继承 GitHub 凭据、runner 命令文件和外部工具授权，以及超过 1 MB 的 CLI JSON 在立即退出后仍完整读取。工作流的 `pull_request` 校验 job 不接收模型 Secret；业务代码应另按知识库列出的现有测试执行。
 
 参考：[GitHub Actions 安全指南](https://docs.github.com/en/actions/reference/security/secure-use)。

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import subprocess
+import tempfile
 import urllib.parse
 import urllib.request
 from pathlib import Path, PurePosixPath
@@ -335,13 +336,17 @@ def run_review(work, executable):
         "--system-prompt",
         system,
     ]
-    completed = subprocess.run(
-        command, input=prompt, text=True, cwd=work / "source", env=env, capture_output=True, timeout=900
-    )
-    # Raw transcripts can contain source or secrets; never print or upload them.
-    if completed.returncode != 0:
-        raise ValueError(f"CodeBuddy failed (exit {completed.returncode}); no review published")
-    value = parse_result(completed.stdout, metadata["anchors"])
+    # A CLI can exit with asynchronous pipe writes still buffered, truncating long
+    # JSON even with exit 0. Regular files make Node's output writes synchronous.
+    # TemporaryFile is private and removed on close; transcripts are never uploaded.
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stdout, tempfile.TemporaryFile() as stderr:
+        completed = subprocess.run(
+            command, input=prompt, text=True, cwd=work / "source", env=env, stdout=stdout, stderr=stderr, timeout=900
+        )
+        if completed.returncode != 0:
+            raise ValueError(f"CodeBuddy failed (exit {completed.returncode}); no review published")
+        stdout.seek(0)
+        value = parse_result(stdout.read(), metadata["anchors"])
     if key in json.dumps(value, ensure_ascii=False):
         raise ValueError("Credential detected in model output; refusing to publish")
     (work / "review.json").write_text(json.dumps(value, ensure_ascii=False))

--- a/.github/scripts/test_ai_review.py
+++ b/.github/scripts/test_ai_review.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from contextlib import contextmanager
@@ -122,8 +123,13 @@ class ReviewTests(unittest.TestCase):
             (work / "source").mkdir()
             (work / "metadata.json").write_text(json.dumps(metadata))
             (work / "diff.txt").write_text("+changed line\n")
+
+            def complete_review(*args, **kwargs):
+                kwargs["stdout"].write(json.dumps(result))
+                return subprocess.CompletedProcess([], 0)
+
             with patch.dict(os.environ, inherited, clear=True), patch.object(
-                review.subprocess, "run", return_value=subprocess.CompletedProcess([], 0, json.dumps(result), "")
+                review.subprocess, "run", side_effect=complete_review
             ) as run:
                 review.run_review(work, "codebuddy")
             command = run.call_args.args[0]
@@ -148,6 +154,29 @@ class ReviewTests(unittest.TestCase):
             self.assertEqual(command[command.index("--mcp-config") + 1], '{"mcpServers":{}}')
             self.assertIn("--strict-mcp-config", command)
             self.assertEqual(command[command.index("--setting-sources") + 1], "none")
+            self.assertEqual(json.loads((work / "review.json").read_text()), self.value)
+
+    def test_large_cli_json_survives_immediate_process_exit(self):
+        metadata = {"number": 1, "merge_base": "b", "head": "a", "omitted": [], "anchors": self.anchors}
+        # Reproduce a CLI that exits before pending asynchronous pipe writes drain.
+        messages = [
+            {"type": "assistant", "text": "x" * 1_048_576},
+            {"type": "result", "subtype": "success", "structured_output": self.value},
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            work = Path(directory)
+            (work / "source").mkdir()
+            (work / "metadata.json").write_text(json.dumps(metadata))
+            (work / "diff.txt").write_text("+changed line\n")
+            executable = work / "fake-codebuddy"
+            executable.write_text(
+                "#!" + sys.executable + "\nimport os, sys\n"
+                "sys.stdin.read()\nos.set_blocking(1, False)\n"
+                "os.write(1, " + repr(json.dumps(messages).encode()) + ")\nos._exit(0)\n"
+            )
+            executable.chmod(0o700)
+            with patch.dict(os.environ, {"CODEBUDDY_API_KEY": "test-model-key"}):
+                review.run_review(work, str(executable))
             self.assertEqual(json.loads((work / "review.json").read_text()), self.value)
 
     @contextmanager

--- a/.github/scripts/test_ai_review.py
+++ b/.github/scripts/test_ai_review.py
@@ -102,6 +102,54 @@ class ReviewTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             review.validate_findings(self.value, self.anchors)
 
+    def test_model_process_has_no_github_credentials_or_external_tool_permissions(self):
+        metadata = {"number": 1, "merge_base": "b", "head": "a", "omitted": [], "anchors": self.anchors}
+        result = [{"type": "result", "subtype": "success", "structured_output": self.value}]
+        inherited = {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/test-home",
+            "CODEBUDDY_API_KEY": "test-model-key",
+            "GH_TOKEN": "test-github-token",
+            "GITHUB_TOKEN": "test-github-token",
+            "GITHUB_ENV": "/runner/environment",
+            "GITHUB_OUTPUT": "/runner/output",
+            "GITHUB_PATH": "/runner/path",
+            "GITHUB_STEP_SUMMARY": "/runner/summary",
+            "CODEBUDDY_CONFIG_DIR": "/untrusted-config",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            work = Path(directory)
+            (work / "source").mkdir()
+            (work / "metadata.json").write_text(json.dumps(metadata))
+            (work / "diff.txt").write_text("+changed line\n")
+            with patch.dict(os.environ, inherited, clear=True), patch.object(
+                review.subprocess, "run", return_value=subprocess.CompletedProcess([], 0, json.dumps(result), "")
+            ) as run:
+                review.run_review(work, "codebuddy")
+            command = run.call_args.args[0]
+            options = run.call_args.kwargs
+            self.assertEqual(options["cwd"], work / "source")
+            self.assertEqual(
+                options["env"],
+                {
+                    "PATH": inherited["PATH"],
+                    "HOME": inherited["HOME"],
+                    "CODEBUDDY_API_KEY": "test-model-key",
+                    "CODEBUDDY_INTERNET_ENVIRONMENT": "iOA",
+                    "CODEBUDDY_CONFIG_DIR": str(work / "config"),
+                    "CI": "true",
+                    "CLIENT_INFO_PRODUCT_VERSION": "2.147.0",
+                },
+            )
+            self.assertEqual(command[command.index("--tools") + 1], "Read,Glob,Grep,StructuredOutput")
+            # Bare Read/Glob/Grep in allowedTools would bypass the snapshot's default read boundary.
+            self.assertEqual(command[command.index("--allowedTools") + 1], "StructuredOutput")
+            self.assertEqual(command[command.index("--permission-mode") + 1], "dontAsk")
+            self.assertEqual(command[command.index("--mcp-config") + 1], '{"mcpServers":{}}')
+            self.assertIn("--strict-mcp-config", command)
+            self.assertEqual(command[command.index("--setting-sources") + 1], "none")
+            self.assertEqual(json.loads((work / "review.json").read_text()), self.value)
+
     @contextmanager
     def snapshot_repository(self):
         previous = Path.cwd()

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -38,8 +38,25 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Check target-branch review installation
+        id: installation
+        run: |
+          present=0
+          for file in .github/scripts/ai_review.py .ai/review/knowledge.md .ai/review/rules.md; do
+            if [ -f "$file" ]; then present=$((present + 1)); fi
+          done
+          if [ "$present" -eq 0 ]; then
+            echo '::notice::AI review is not installed on this target branch yet; no model review was performed.'
+            echo 'installed=false' >> "$GITHUB_OUTPUT"
+          elif [ "$present" -ne 3 ]; then
+            echo '::error::Target branch has an incomplete AI review installation.'
+            exit 1
+          else
+            echo 'installed=true' >> "$GITHUB_OUTPUT"
+          fi
       - name: Check access and prepare source snapshot
         id: prepare
+        if: steps.installation.outputs.installed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: python3 -I .github/scripts/ai_review.py prepare --work-dir "$RUNNER_TEMP/ai-review"


### PR DESCRIPTION
#289 合入后，真实审查在模型步骤退出 0 时得到被截断的 JSON，解析失败且没有发布评论：[失败运行](https://github.com/TencentBlueKing/bamboo-engine/actions/runs/34353113011)。长对话输出通过管道传输时，CLI 退出可能早于异步输出排空；本地最小 Node 样例稳定只得到 64 KiB 的不完整 JSON。

本 PR 将 CLI stdout/stderr 接入私有临时文件，保证常规文件同步输出，结束后删除。保持模型只读工具、凭据隔离、严格结果及差异行校验、独立评论发布，不接受截断结果、不上传原始对话。

新增两项回归：模型进程不继承 GitHub 凭据/runner 命令文件/外部工具授权；模拟 CLI 非阻塞写出超过 1 MiB JSON 后立即退出，旧实现失败、新实现通过。接入说明明确 GitHub 当前从默认分支读取 pull_request_target 工作流，再由本方案显式检出 PR base 的审查脚本和规则。默认入口检测目标尚未安装时明确跳过模型；部分安装则失败。各 LTS 单独补齐脚本/知识，仓库 Secret 共享，已有 PR 需后续事件触发。

验证：全部 17 项 runner 单测、Black、isort、Flake8、差异检查通过。工作流通过 actionlint 和三种安装状态（全缺/部分缺/齐全）执行校验。修复后的真实 GLM-5.3 复核已在本地通过：对原验证 PR head 57ecdf7 收到完整 208,321 字节 JSON、CLI exit 0、25 条消息，结果结构及差异行校验通过，实际模型 glm-5.3-ioa；原始对话未保存/上传。该结果证明修复后的模型输出链路，尚未证明 GitHub 评论发布恢复；pull_request_target 使用目标分支版本，因此本 PR 合入之前仍会运行旧 runner，不能把新版本的单测通过等同于线上审查已恢复。本 PR 不修改业务源码，也未执行完整业务测试或部署。
