### PR TITLE
chore(release): prepare engine 2.6.8

### DIFF
--- a/bamboo_engine/__version__.py
+++ b/bamboo_engine/__version__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-__version__ = "2.6.7"
+__version__ = "2.6.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-engine"
-version = "2.6.7"
+version = "2.6.8"
 description = "Bamboo-engine is a general-purpose workflow engine"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"


### PR DESCRIPTION
为已合入 3.24 LTS 的 #296 发布 bamboo-engine 2.6.8，同步 pyproject.toml 和 __version__.py 两处版本号。

此版本使隔离渲染的基础设施故障显式失败，覆盖插件执行、调度及检查点恢复。配套 legacy pipeline 改动会随后通过 bamboo-pipeline 3.24.19 发布，依赖固定为 2.6.8。

验证：合入代码与 #296 最终通过的 18 项测试 CI 中业务源码一致；本地 Python 3.6/3.7 引擎测试各 425 passed、1 skipped（Linux 资源限制用例），Poetry 配置检查及 wheel/sdist 构建通过，产物版本、依赖和关键源码已核验。本 PR 完整 CI 通过后合入并推送发布 tag。
