### PR TITLE
chore(release): prepare pipeline 3.24.19

### DIFF
--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "3.24.18"
+__version__ = "3.24.19"

--- a/runtime/bamboo-pipeline/poetry.lock
+++ b/runtime/bamboo-pipeline/poetry.lock
@@ -66,7 +66,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "bamboo-engine"
-version = "2.6.7"
+version = "2.6.8"
 description = "Bamboo-engine is a general-purpose workflow engine"
 category = "main"
 optional = false
@@ -811,7 +811,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">= 3.6, < 3.8"
-content-hash = "4a60749403e77803fec09f43f1b7a0b3e89722d19decbf5134c19f4038c19382"
+content-hash = "841eebbf288ce85d7c4e07cf6290a595d91623553a65b6014013d42c6a0413b4"
 
 [metadata.files]
 amqp = []
@@ -824,8 +824,8 @@ async-timeout = []
 atomicwrites = []
 attrs = []
 bamboo-engine = [
-    {file = "bamboo_engine-2.6.7-py3-none-any.whl", hash = "sha256:99f1bd2d1df04374a744324486fb6c2fae857747d7748a1b7c01259fa127f518"},
-    {file = "bamboo_engine-2.6.7.tar.gz", hash = "sha256:15b54106de64cce6b0b0b9f36445cb6a14541262fee511a5553e4549171d268a"},
+    {file = "bamboo_engine-2.6.8-py3-none-any.whl", hash = "sha256:23d25513cf5bfa4be8792257717b63a3d45fa9a2dc0387cb94e48fd705fdd058"},
+    {file = "bamboo_engine-2.6.8.tar.gz", hash = "sha256:29a309a4ade12d608dfb1df60a67115c9bb62af99dd492ef9954ffad596bc5d6"},
 ]
 billiard = []
 black = []

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "3.24.18"
+version = "3.24.19"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"
@@ -16,7 +16,7 @@ requests = "^2.22"
 django-celery-beat = "^2.1"
 Mako = "^1.1.4"
 pytz = ">=2019.3"
-bamboo-engine = "2.6.7"
+bamboo-engine = "2.6.8"
 jsonschema = "^2.5.1"
 ujson = "^4"
 pyparsing = "^2.2"


### PR DESCRIPTION
为已合入 3.24 LTS 的 #296 发布 bamboo-pipeline 3.24.19，将 engine 精确依赖从 2.6.7 更新到已发布的 2.6.8，使旧引擎的隔离渲染故障处理随 runtime 包交付。

同步两处 pipeline 版本号及 poetry.lock。使用 Poetry 1.1.14 执行 lock --no-update 后，保留新 engine 条目、产物哈希和 content hash；其余 65 个包及原有哈希记录保持不变，最终仅 3 文件、7 行增删。

验证：
- engine 2.6.8 正式发包工作流成功；PyPI wheel/sdist SHA256 与 64 个 Python 源文件均已核验；从 PyPI 安装后的真实子进程渲染、开启 fallback 时的基础设施显式失败均通过。
- lock freshness、Poetry 配置检查和本地 wheel/sdist 构建通过；按正式 workflow 排除测试目录后，产物版本、engine ==2.6.8 依赖及旧引擎处理代码已核验。
- engine 版本 PR #297 的完整 CI 18/18 通过。其中一个旧多回调测试首次超时，原提交重跑成功；相关并发计数问题在旧基线已存在，本次未修复该独立问题。

本 PR 完整 CI 通过后合入并发布 bamboo-pipeline-v3.24.19。bk-sops SystemObject 修复仍由 TencentBlueKing/bk-sops#8521 单独交付，本次不修改应用配置。
