### PR TITLE
minor: release bamboo-engine 3.0.6 --story=860752509

### DIFF
--- a/bamboo_engine/__version__.py
+++ b/bamboo_engine/__version__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-__version__ = "3.0.5"
+__version__ = "3.0.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-engine"
-version = "3.0.5"
+version = "3.0.6"
 description = "Bamboo-engine is a general-purpose workflow engine"
 authors = ["homholueng <homholueng@gmail.com>"]
 license = "MIT"

--- a/runtime/bamboo-pipeline/pipeline/engine/core/schedule.py
+++ b/runtime/bamboo-pipeline/pipeline/engine/core/schedule.py
@@ -77,7 +77,6 @@ def schedule(process_id, schedule_id, data_id=None):
             return
 
         # check whether the node is in a state waiting for scheduling
-        service_act = sched_service.service_act
         act_id = sched_service.activity_id
         version = sched_service.version
 
@@ -120,6 +119,16 @@ def schedule(process_id, schedule_id, data_id=None):
 
         celery_logger.info("[pipeline-trace] schedule node %s with version %s" % (act_id, version))
         with auto_release_schedule_lock(schedule_id):
+            # Another callback may have committed after our first read but before we acquired the lock.
+            # Use its latest outputs/counter and never revive a schedule it already finished.
+            try:
+                sched_service = ScheduleService.objects.get(id=schedule_id)
+            except ScheduleService.DoesNotExist:
+                return
+            if sched_service.is_finished:
+                return
+            service_act = sched_service.service_act
+
             # get data
             parent_data = get_schedule_parent_data(sched_service.id)
             if parent_data is None:

--- a/runtime/bamboo-pipeline/pipeline/tests/engine/core/test_schedule_snapshot.py
+++ b/runtime/bamboo-pipeline/pipeline/tests/engine/core/test_schedule_snapshot.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""A callback must use state committed before it acquires the scheduling lock."""
+from unittest import mock
+
+from django.test import TestCase
+from pipeline.core.data.base import DataObject
+from pipeline.core.flow import Service, ServiceActivity
+from pipeline.engine import states
+from pipeline.engine.core import schedule
+from pipeline.engine.models import ScheduleService, Status
+
+
+class CountingCallbackService(Service):
+    __need_schedule__ = True
+    __multi_callback_enabled__ = True
+    interval = None
+
+    def execute(self, data, parent_data):
+        return True
+
+    def schedule(self, data, parent_data, callback_data=None):
+        data.set_outputs("count", data.get_one_of_outputs("count", 0) + 1)
+        return True
+
+
+class ScheduleSnapshotTestCase(TestCase):
+    def setUp(self):
+        self.node_id = "a" * 32
+        self.version = "b" * 32
+        self.schedule_id = self.node_id + self.version
+        self.node = ServiceActivity(self.node_id, CountingCallbackService(), data=DataObject({}))
+        Status.objects.create(id=self.node_id, state=states.RUNNING, version=self.version)
+        ScheduleService.objects.create(
+            id=self.schedule_id,
+            activity_id=self.node_id,
+            version=self.version,
+            process_id="c" * 32,
+            service_act=self.node,
+            wait_callback=True,
+            multi_callback_enabled=True,
+        )
+        for patcher in (
+            mock.patch("pipeline.engine.core.schedule.get_schedule_parent_data", return_value=DataObject({})),
+            mock.patch("pipeline.engine.core.schedule.set_schedule_data"),
+            mock.patch("pipeline.engine.models.Data.objects.write_node_data"),
+        ):
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def run_after_other_callback_commits(self, **updates):
+        real_get = ScheduleService.objects.get
+        first_read = True
+
+        def read_then_commit(*args, **kwargs):
+            nonlocal first_read
+            stale = real_get(*args, **kwargs)
+            if first_read:
+                first_read = False
+                # Deterministically place another worker's commit between our read and lock acquisition.
+                ScheduleService.objects.filter(id=self.schedule_id).update(**updates)
+            return stale
+
+        with mock.patch.object(ScheduleService.objects, "get", side_effect=read_then_commit):
+            schedule.schedule("c" * 32, self.schedule_id)
+        return real_get(id=self.schedule_id)
+
+    def test_callback_preserves_preceding_committed_count(self):
+        self.node.data.set_outputs("count", 4)
+        result = self.run_after_other_callback_commits(service_act=self.node, schedule_times=4)
+        self.assertEqual(result.service_act.data.get_one_of_outputs("count"), 5)
+        self.assertEqual(result.schedule_times, 5)
+        self.assertFalse(result.is_scheduling)
+
+    def test_callback_does_not_reopen_a_finished_schedule(self):
+        result = self.run_after_other_callback_commits(is_finished=True, service_act=None, schedule_times=5)
+        self.assertTrue(result.is_finished)
+        self.assertIsNone(result.service_act)
+        self.assertEqual(result.schedule_times, 5)
+        self.assertFalse(result.is_scheduling)


### PR DESCRIPTION
发布 4.0 LTS 的 bamboo-engine 3.0.6，承接已合入 #299 的修复，供标准运维 HB 和多租户分支使用。同步 engine 两处版本号；配套 bamboo-pipeline 4.0.5 将精确依赖 engine 3.0.6。

发布 CI 暴露旧引擎多回调竞态：调度对象在获锁前加载，前一回调的更新可能被后续旧快照覆盖，导致计数丢失或重新写回已完成的调度。本次在获锁后重新读取最新对象并检查完成状态，保持原有并发端到端测试的回调数量及断言不变。该问题在 pipeline 4.0.4 的旧 scheduler 中已存在；修复只涉及 legacy scheduler，随配套 pipeline 包发布。

验证：
- 新增真实数据库交错时序回归：旧实现稳定出现 count=1（期望5）和已完成状态被覆盖；修复后旧引擎核心 89 项测试通过。
- Python 3.11.4 engine 本地测试 568 passed、1 项平台条件跳过。
- Poetry 2.0 结构校验 0 错误、lock fresh（沿用基线的 5 条旧配置格式弃用提示）；engine wheel/sdist 已构建，版本、Python 约束及 65 个 Python 源文件核对通过。
- 首轮及原提交重跑 legacy E2E 均为 76 passed / 1 failed；修复后完整 6 项 CI 全部通过：https://github.com/TencentBlueKing/bamboo-engine/actions/runs/34585995044 ，验证提交 0d7a3727d425421b4eb2156d339a75fc45aba409。

先确认 engine 正式 PyPI wheel/sdist 可用，再更新 pipeline 版本、精确依赖和 lock 并发布。bk-sops 两个依赖 PR 将分别指向 release_humming_bird 与 dev_multi_tenant。
