### PR TITLE
minor: release bamboo-pipeline 4.0.5 --story=860752509

### DIFF
--- a/runtime/bamboo-pipeline/pipeline/__init__.py
+++ b/runtime/bamboo-pipeline/pipeline/__init__.py
@@ -13,4 +13,4 @@ specific language governing permissions and limitations under the License.
 
 default_app_config = "pipeline.apps.PipelineConfig"
 
-__version__ = "4.0.4"
+__version__ = "4.0.5"

--- a/runtime/bamboo-pipeline/poetry.lock
+++ b/runtime/bamboo-pipeline/poetry.lock
@@ -65,14 +65,14 @@ tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "bamboo-engine"
-version = "3.0.5"
+version = "3.0.6"
 description = "Bamboo-engine is a general-purpose workflow engine"
 optional = false
 python-versions = "<3.12,>=3.11"
 groups = ["main"]
 files = [
-    {file = "bamboo_engine-3.0.5-py3-none-any.whl", hash = "sha256:484fdda2d1d1f709d300dde4783ac24c59c5c8f7ea47af376dba2762f0a72d25"},
-    {file = "bamboo_engine-3.0.5.tar.gz", hash = "sha256:2b642b1c72b933340a4e37938a2409737d8e2843f9d460d0e3453318d595a375"},
+    {file = "bamboo_engine-3.0.6-py3-none-any.whl", hash = "sha256:ffa8f08a94063c48d5312c6e93e4980acd0e5e8247db17fda750cd7676b15a6f"},
+    {file = "bamboo_engine-3.0.6.tar.gz", hash = "sha256:786006d48c3f09fe2c153c7f0807831afb167f42fb8003324aef510d1ab916ab"},
 ]
 
 [package.dependencies]
@@ -1453,4 +1453,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "283cbf605b9ca72985c79aa5fd05b7649f4ae4e75f5508cf877a64637040aaa6"
+content-hash = "a9b0fa1d948d437ec3c0cc155f2b73cd29f8c2fc472362b507421ca0c2a0cb89"

--- a/runtime/bamboo-pipeline/pyproject.toml
+++ b/runtime/bamboo-pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bamboo-pipeline"
-version = "4.0.4"
+version = "4.0.5"
 description = "runtime for bamboo-engine base on Django and Celery"
 authors = ["homholueng <homholueng@gmail.com>"]
 license = "MIT"
@@ -16,7 +16,7 @@ requests = "^2.31"
 django-celery-beat = "^2.5"
 Mako = "^1.3"
 pytz = ">=2019.3"
-bamboo-engine = "3.0.5"
+bamboo-engine = "3.0.6"
 jsonschema = "^4.17.0"
 ujson = "^5.9"
 pyparsing = "^3"


### PR DESCRIPTION
发布 4.0 LTS 的 bamboo-pipeline 4.0.5，精确依赖已发布的 bamboo-engine 3.0.6，供标准运维 release_humming_bird 和 dev_multi_tenant 分支升级。

继承已合入 #299/#300 的修复，包括 Mako 隔离渲染兼容性、基础设施失败传播，以及旧引擎多回调获锁后重新读取最新调度快照。本 PR 仅同步 pipeline 两处版本号、engine 精确依赖及 lock，共 3 个文件、7 行更新。

验证：
- engine 3.0.6 的官方发布流程成功，PyPI wheel/sdist SHA256 与源码核对通过。
- Poetry 2.0 lock 更新仅改变 engine 条目和 content hash，其他锁定依赖完整保持不变；两项产物 hash 与 PyPI 一致，结构校验 0 错误且 lock fresh。
- 按官方流程剔除三个测试目录后，pipeline wheel/sdist 本地构建成功；489 个 Python 源文件逐一核对，元数据精确依赖 engine==3.0.6。
- 业务源码基线 #300 的完整 6 项 CI 已通过：https://github.com/TencentBlueKing/bamboo-engine/actions/runs/34585995044 。本版本提交 c051ac4124c189f82ee2ee456ba70bb172fd2d23 的完整 6 项 CI 也已全部通过：https://github.com/TencentBlueKing/bamboo-engine/actions/runs/34587455902 。

本 PR 不修改新的业务逻辑、运行配置或其他依赖版本。

应用兼容性验证：保持其他147项安装依赖中的非engine/pipeline版本不变，HB全量1061项、多租户全量1122项在升级前后均通过；本地测试使用与分支CI一致的网关stage。
